### PR TITLE
ci: migrate to Ubuntu runners for 10x cost reduction

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   frontend:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -14,11 +14,21 @@ on:
 
 jobs:
   rust:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
 
       - name: Setup mise
         uses: jdx/mise-action@9dc7d5dd454262207dea3ab5a06a3df6afc8ff26 # v3.4.1


### PR DESCRIPTION
## Motivation

GitHub Actions free tier gives 2000 min/month for Linux but macOS counted as 10x (effective 200 min/month). Switching to Ubuntu saves 90% CI costs.

## Implementation information

Changed both workflows from `macos-latest` to `ubuntu-latest`:
- **ci-frontend.yml**: Simple runner swap (no extra deps needed)
- **ci-rust.yml**: Added Tauri Linux deps (libgtk-3, libwebkit2gtk-4.1, etc.)

Tradeoffs:
- ✅ 10x cheaper (2000 vs 200 effective minutes)
- ✅ Faster runners
- ❌ Can't build .dmg/.app bundles (keep macOS for releases)

## Supporting documentation

GitHub Actions pricing: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers