### PR TITLE
feat: filter app installer volumes from import view

### DIFF
--- a/src-tauri/src/modules/sd_card.rs
+++ b/src-tauri/src/modules/sd_card.rs
@@ -516,21 +516,24 @@ mod tests {
         // Note: diskutil output has multiple spaces, we match with a single space after colon
 
         // Simulate diskutil output for Secure Digital protocol (with multiple spaces like real output)
-        let sd_output = "   Protocol:                  Secure Digital\n   Device Location:           Internal";
-        let has_sd_protocol = sd_output
-            .lines()
-            .any(|line| line.trim_start().starts_with("Protocol:") && line.contains("Secure Digital"));
+        let sd_output =
+            "   Protocol:                  Secure Digital\n   Device Location:           Internal";
+        let has_sd_protocol = sd_output.lines().any(|line| {
+            line.trim_start().starts_with("Protocol:") && line.contains("Secure Digital")
+        });
         assert!(has_sd_protocol);
 
         // Simulate diskutil output for USB protocol
-        let usb_output = "   Protocol:                  USB\n   Device Location:           External";
+        let usb_output =
+            "   Protocol:                  USB\n   Device Location:           External";
         let has_usb_protocol = usb_output
             .lines()
             .any(|line| line.trim_start().starts_with("Protocol:") && line.contains("USB"));
         assert!(has_usb_protocol);
 
         // Simulate diskutil output for Disk Image protocol
-        let disk_image_output = "   Protocol:                  Disk Image\n   Device Location:           External";
+        let disk_image_output =
+            "   Protocol:                  Disk Image\n   Device Location:           External";
         let has_disk_image_protocol = disk_image_output
             .lines()
             .any(|line| line.trim_start().starts_with("Protocol:") && line.contains("Disk Image"));


### PR DESCRIPTION
## Motivation

Import view was showing all mounted volumes including app installer DMGs (disk images), which cluttered the UI and made it harder to find actual photo storage devices (SD cards, USB drives).

## Implementation information

**Two-part fix:**

1. **Improved device type detection** - Added check for `Protocol: Secure Digital` to correctly identify built-in SD card readers (which show as "Internal" location but are still SD cards)

2. **Added volume filtering** - Filter out non-storage devices:
   - Excluded: Disk images (app installers), internal drives, unknown devices
   - Included: SD cards, USB drives, external drives

**Technical details:**
- Modified `get_device_info()` to check Protocol field first for accuracy
- Added filter in `scan_sd_cards()` before pushing to results
- Combined conditions to avoid clippy::if_same_then_else warning

**Testing:**
- Verified with actual volumes:
  - SD card via USB reader (Protocol: USB) → shown ✓
  - SD card via built-in reader (Protocol: Secure Digital) → shown ✓
  - App installer DMG (Protocol: Disk Image) → hidden ✓
- All 231 Rust tests pass

## Supporting documentation

Plan: /Users/marcin.skalski@konghq.com/.claude/plans/dynamic-orbiting-riddle.md