### PR TITLE
fix(frontend): remove eslint-disable comments

### DIFF
--- a/src/components/Import.tsx
+++ b/src/components/Import.tsx
@@ -23,8 +23,7 @@ export function Import({ sdCards, isScanning, onImportComplete }: ImportProps) {
     if (activeCardPath && !sdCards.some((card) => card.path === activeCardPath)) {
       setActiveCardPath(undefined)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sdCards.length, activeCardPath])
+  }, [sdCards, activeCardPath])
 
   // Handle clicks outside the list to collapse active card
   useEffect(() => {

--- a/src/components/NotificationToast.test.tsx
+++ b/src/components/NotificationToast.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { NotificationToast } from './NotificationToast'
-import { NotificationContext, NotificationProvider } from '../contexts/NotificationContext'
+import { NotificationContext } from '../contexts/notification-context'
+import { NotificationProvider } from '../contexts/NotificationContext'
 import { useContext } from 'react'
 
 function TestWrapper({ children }: { children: React.ReactNode }) {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { open } from '@tauri-apps/plugin-dialog'
 import { openUrl } from '@tauri-apps/plugin-opener'
@@ -28,7 +28,115 @@ export function Settings() {
   )
   const [connectingDrive, setConnectingDrive] = useState(false)
 
+  const loadDriveAccount = useCallback(async () => {
+    try {
+      const account = await invoke<GoogleDriveAccount | null>('get_google_drive_account')
+      setDriveAccount(account)
+    } catch (error) {
+      console.error('Failed to load Google Drive account:', error)
+    }
+  }, [])
+
   useEffect(() => {
+    function loadDestinations() {
+      try {
+        const stored = localStorage.getItem('backup_destinations')
+        if (stored) {
+          const parsed: unknown = JSON.parse(stored)
+          if (
+            Array.isArray(parsed) &&
+            parsed.every(
+              (item): item is BackupDestination =>
+                typeof item === 'object' &&
+                item !== null &&
+                'id' in item &&
+                'name' in item &&
+                'path' in item
+            )
+          ) {
+            setDestinations(parsed)
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load destinations:', error)
+      }
+    }
+
+    function loadDeliveryDestinations() {
+      try {
+        const stored = localStorage.getItem('delivery_destinations')
+        if (stored) {
+          const parsed: unknown = JSON.parse(stored)
+          const migrated = migrateDeliveryDestinations(parsed)
+          localStorage.setItem('delivery_destinations', JSON.stringify(migrated))
+          setDeliveryDestinations(migrated)
+        }
+      } catch (error) {
+        console.error('Failed to load delivery destinations:', error)
+      }
+    }
+
+    function loadDefaultImportLocation() {
+      try {
+        const stored = localStorage.getItem('default_import_location')
+        if (stored) {
+          setDefaultImportLocation(stored)
+        }
+      } catch (error) {
+        console.error('Failed to load default import location:', error)
+      }
+    }
+
+    function loadArchiveLocation() {
+      try {
+        const stored = localStorage.getItem('archive_location')
+        if (stored) {
+          setArchiveLocation(stored)
+        }
+      } catch (error) {
+        console.error('Failed to load archive location:', error)
+      }
+    }
+
+    function loadTemplates() {
+      try {
+        const storedFolderTemplate = localStorage.getItem('folder_template')
+        const storedFileTemplate = localStorage.getItem('file_rename_template')
+        if (storedFolderTemplate) {
+          setFolderTemplate(storedFolderTemplate)
+        }
+        if (storedFileTemplate) {
+          setFileRenameTemplate(storedFileTemplate)
+        }
+      } catch (error) {
+        console.error('Failed to load templates:', error)
+        showError('Failed to load template settings')
+      }
+    }
+
+    function loadAutoEject() {
+      try {
+        const stored = localStorage.getItem('auto_eject')
+        if (stored) {
+          setAutoEject(stored === 'true')
+        }
+      } catch (error) {
+        console.error('Failed to load auto-eject setting:', error)
+        showError('Failed to load auto-eject setting')
+      }
+    }
+
+    function loadDriveConflictMode() {
+      try {
+        const stored = localStorage.getItem('drive_conflict_mode')
+        if (stored && (stored === 'overwrite' || stored === 'rename' || stored === 'skip')) {
+          setDriveConflictMode(stored)
+        }
+      } catch (error) {
+        console.error('Failed to load conflict mode:', error)
+      }
+    }
+
     loadDestinations()
     loadDeliveryDestinations()
     loadDefaultImportLocation()
@@ -37,32 +145,7 @@ export function Settings() {
     loadAutoEject()
     loadDriveAccount().catch(console.error)
     loadDriveConflictMode()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  function loadDestinations() {
-    try {
-      const stored = localStorage.getItem('backup_destinations')
-      if (stored) {
-        const parsed: unknown = JSON.parse(stored)
-        if (
-          Array.isArray(parsed) &&
-          parsed.every(
-            (item): item is BackupDestination =>
-              typeof item === 'object' &&
-              item !== null &&
-              'id' in item &&
-              'name' in item &&
-              'path' in item
-          )
-        ) {
-          setDestinations(parsed)
-        }
-      }
-    } catch (error) {
-      console.error('Failed to load destinations:', error)
-    }
-  }
+  }, [loadDriveAccount, showError])
 
   function saveDestinations(dests: BackupDestination[]) {
     localStorage.setItem('backup_destinations', JSON.stringify(dests))
@@ -105,42 +188,6 @@ export function Settings() {
 
   function removeDestination(id: string) {
     saveDestinations(destinations.filter((d) => d.id !== id))
-  }
-
-  function loadDeliveryDestinations() {
-    try {
-      const stored = localStorage.getItem('delivery_destinations')
-      if (stored) {
-        const parsed: unknown = JSON.parse(stored)
-        const migrated = migrateDeliveryDestinations(parsed)
-        localStorage.setItem('delivery_destinations', JSON.stringify(migrated))
-        setDeliveryDestinations(migrated)
-      }
-    } catch (error) {
-      console.error('Failed to load delivery destinations:', error)
-    }
-  }
-
-  function loadDefaultImportLocation() {
-    try {
-      const stored = localStorage.getItem('default_import_location')
-      if (stored) {
-        setDefaultImportLocation(stored)
-      }
-    } catch (error) {
-      console.error('Failed to load default import location:', error)
-    }
-  }
-
-  function loadArchiveLocation() {
-    try {
-      const stored = localStorage.getItem('archive_location')
-      if (stored) {
-        setArchiveLocation(stored)
-      }
-    } catch (error) {
-      console.error('Failed to load archive location:', error)
-    }
   }
 
   function saveDeliveryDestinations(dests: DeliveryDestination[]) {
@@ -212,34 +259,6 @@ export function Settings() {
     await selectStorageLocation('archive_location', setArchiveLocation)
   }
 
-  function loadTemplates() {
-    try {
-      const storedFolderTemplate = localStorage.getItem('folder_template')
-      const storedFileTemplate = localStorage.getItem('file_rename_template')
-      if (storedFolderTemplate) {
-        setFolderTemplate(storedFolderTemplate)
-      }
-      if (storedFileTemplate) {
-        setFileRenameTemplate(storedFileTemplate)
-      }
-    } catch (error) {
-      console.error('Failed to load templates:', error)
-      showError('Failed to load template settings')
-    }
-  }
-
-  function loadAutoEject() {
-    try {
-      const stored = localStorage.getItem('auto_eject')
-      if (stored) {
-        setAutoEject(stored === 'true')
-      }
-    } catch (error) {
-      console.error('Failed to load auto-eject setting:', error)
-      showError('Failed to load auto-eject setting')
-    }
-  }
-
   function saveFolderTemplate(template: string) {
     localStorage.setItem('folder_template', template)
     setFolderTemplate(template)
@@ -259,26 +278,6 @@ export function Settings() {
   function resetTemplates() {
     saveFolderTemplate(DEFAULT_FOLDER_TEMPLATE)
     saveFileRenameTemplate(DEFAULT_FILE_TEMPLATE)
-  }
-
-  async function loadDriveAccount() {
-    try {
-      const account = await invoke<GoogleDriveAccount | null>('get_google_drive_account')
-      setDriveAccount(account)
-    } catch (error) {
-      console.error('Failed to load Google Drive account:', error)
-    }
-  }
-
-  function loadDriveConflictMode() {
-    try {
-      const stored = localStorage.getItem('drive_conflict_mode')
-      if (stored && (stored === 'overwrite' || stored === 'rename' || stored === 'skip')) {
-        setDriveConflictMode(stored)
-      }
-    } catch (error) {
-      console.error('Failed to load conflict mode:', error)
-    }
   }
 
   function saveDriveConflictMode(mode: 'overwrite' | 'rename' | 'skip') {

--- a/src/contexts/NotificationContext.test.tsx
+++ b/src/contexts/NotificationContext.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, renderHook } from '@testing-library/react'
-import { NotificationContext, NotificationProvider } from './NotificationContext'
+import { NotificationContext } from './notification-context'
+import { NotificationProvider } from './NotificationContext'
 import { useContext } from 'react'
 
 describe('notificationContext', () => {

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import type { ReactNode } from 'react'
 import { createContext, useCallback, useState } from 'react'
 

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,28 +1,10 @@
 import type { ReactNode } from 'react'
-import { createContext, useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
+
+import type { Notification, NotificationType } from './notification-context'
+import { NotificationContext } from './notification-context'
 
 const DEFAULT_NOTIFICATION_DURATION = 5000
-
-export type NotificationType = 'success' | 'error' | 'warning' | 'info'
-
-export interface Notification {
-  id: string
-  type: NotificationType
-  message: string
-  duration?: number
-}
-
-interface NotificationContextType {
-  notifications: Notification[]
-  addNotification: (type: NotificationType, message: string, duration?: number) => void
-  removeNotification: (id: string) => void
-  success: (message: string, duration?: number) => void
-  error: (message: string, duration?: number) => void
-  warning: (message: string, duration?: number) => void
-  info: (message: string, duration?: number) => void
-}
-
-export const NotificationContext = createContext<NotificationContextType | undefined>(undefined)
 
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<Notification[]>([])

--- a/src/contexts/notification-context.ts
+++ b/src/contexts/notification-context.ts
@@ -1,0 +1,29 @@
+import { createContext } from 'react'
+
+type NotificationType = 'success' | 'error' | 'warning' | 'info'
+
+interface Notification {
+  id: string
+  type: NotificationType
+  message: string
+  duration?: number
+}
+
+interface NotificationContextType {
+  notifications: Notification[]
+  addNotification: (type: NotificationType, message: string, duration?: number) => void
+  removeNotification: (id: string) => void
+  success: (message: string, duration?: number) => void
+  error: (message: string, duration?: number) => void
+  warning: (message: string, duration?: number) => void
+  info: (message: string, duration?: number) => void
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined)
+
+export {
+  type NotificationType,
+  type Notification,
+  type NotificationContextType,
+  NotificationContext,
+}

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react'
-import { NotificationContext } from '../contexts/NotificationContext'
+
+import { NotificationContext } from '../contexts/notification-context'
 
 export function useNotification() {
   const context = useContext(NotificationContext)


### PR DESCRIPTION
## Motivation

3 `eslint-disable` comments existed in the codebase, violating the CLAUDE.md rule forbidding linter disables. Each hid a real code quality issue rather than addressing the root cause.

## Implementation information

- `NotificationContext.tsx` — had `eslint-disable react-refresh/only-export-components` because the context object and hook were co-located. Fixed by extracting the raw context object to `notification-context.ts`, keeping the provider in `NotificationContext.tsx` and the hook in `useNotification.ts`.
- `Import.tsx` — had `eslint-disable-next-line react-hooks/exhaustive-deps` on a `useEffect`. Fixed by refactoring the effect to declare all dependencies properly without triggering infinite loops.
- `Settings.tsx` — same pattern as Import.tsx; refactored `useEffect` dependency arrays to include all referenced values.

Closes https://github.com/Automaat/creatorops/issues/156