### PR TITLE
feat(frontend): add React error boundaries

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -335,10 +335,9 @@ Semantic HTML (`<button>` not `<div onClick>`), `:focus-visible`, `.visually-hid
 1. Frontend: `alert()` → NotificationContext
 2. Backend: `Result<T, String>` → custom errors with `thiserror`
 3. Backend: `eprintln!` → `log` crate
-4. No React error boundaries
-5. SQLite: no transactions
-6. `Settings.tsx:30`: fix `eslint-disable`
-7. `Projects.tsx:124-137`: extract inline styles
+4. SQLite: no transactions
+5. `Settings.tsx:30`: fix `eslint-disable`
+6. `Projects.tsx:124-137`: extract inline styles
 
 ## Questions for AI
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,9 @@ function ViewWrapper({ isActive, name, children }: ViewWrapperProps) {
   const className = isActive ? 'view-active' : 'view-hidden'
   return (
     <div className={className}>
-      <ErrorBoundary name={name}>{children}</ErrorBoundary>
+      <ErrorBoundary name={name} isActive={isActive}>
+        {children}
+      </ErrorBoundary>
     </div>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,22 @@
 import { useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
 import { invoke } from '@tauri-apps/api/core'
-import { Layout } from './components/Layout'
+
+import { CommandPalette } from './components/CommandPalette'
 import { Dashboard } from './components/Dashboard'
-import { Import } from './components/Import'
-import { Projects } from './components/Projects'
 import { BackupQueue } from './components/BackupQueue'
 import { Delivery } from './components/Delivery'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { History } from './components/History'
-import { Settings } from './components/Settings'
-import { NotificationToast } from './components/NotificationToast'
+import { Import } from './components/Import'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp'
-import { CommandPalette } from './components/CommandPalette'
-import { useTheme } from './hooks/useTheme'
-import { useSDCardScanner } from './hooks/useSDCardScanner'
+import { Layout } from './components/Layout'
+import { NotificationToast } from './components/NotificationToast'
+import { Projects } from './components/Projects'
+import { Settings } from './components/Settings'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { useSDCardScanner } from './hooks/useSDCardScanner'
+import { useTheme } from './hooks/useTheme'
 import type { Project } from './types'
 
 type View = 'dashboard' | 'import' | 'projects' | 'backup' | 'delivery' | 'history' | 'settings'
@@ -21,6 +24,21 @@ type View = 'dashboard' | 'import' | 'projects' | 'backup' | 'delivery' | 'histo
 function isView(value: string): value is View {
   return ['dashboard', 'import', 'projects', 'backup', 'delivery', 'history', 'settings'].includes(
     value
+  )
+}
+
+interface ViewWrapperProps {
+  isActive: boolean
+  name: string
+  children: ReactNode
+}
+
+function ViewWrapper({ isActive, name, children }: ViewWrapperProps) {
+  const className = isActive ? 'view-active' : 'view-hidden'
+  return (
+    <div className={className}>
+      <ErrorBoundary name={name}>{children}</ErrorBoundary>
+    </div>
   )
 }
 
@@ -163,35 +181,35 @@ function App() {
         importCount={sdCards.length}
         projectsCount={projectsCount}
       >
-        <div style={{ display: currentView === 'dashboard' ? 'block' : 'none' }}>
+        <ViewWrapper isActive={currentView === 'dashboard'} name="Dashboard">
           <Dashboard onProjectClick={handleNavigateToProject} />
-        </div>
-        <div style={{ display: currentView === 'import' ? 'block' : 'none' }}>
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'import'} name="Import">
           <Import
             sdCards={sdCards}
             isScanning={isScanning}
             onImportComplete={handleNavigateToProject}
           />
-        </div>
-        <div style={{ display: currentView === 'projects' ? 'block' : 'none' }}>
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'projects'} name="Projects">
           <Projects
             key={`${selectedProjectId ?? 'projects-list'}-${projectsResetKey}`}
             initialSelectedProjectId={selectedProjectId}
             onBackFromProject={handleBackFromProject}
           />
-        </div>
-        <div style={{ display: currentView === 'backup' ? 'block' : 'none' }}>
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'backup'} name="Backup Queue">
           <BackupQueue />
-        </div>
-        <div style={{ display: currentView === 'delivery' ? 'block' : 'none' }}>
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'delivery'} name="Delivery">
           <Delivery />
-        </div>
-        <div style={{ display: currentView === 'history' ? 'block' : 'none' }}>
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'history'} name="History">
           <History />
-        </div>
-        <div style={{ display: currentView === 'settings' ? 'block' : 'none' }}>
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'settings'} name="Settings">
           <Settings />
-        </div>
+        </ViewWrapper>
       </Layout>
       <NotificationToast />
       <KeyboardShortcutsHelp

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -10,7 +10,7 @@ function Thrower({ shouldThrow }: { shouldThrow: boolean }) {
   return <div>content</div>
 }
 
-function AlwaysThrows() {
+function AlwaysThrows(): never {
   throw new Error('Component crashed')
 }
 

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -70,6 +70,49 @@ describe('error boundary', () => {
     spy.mockRestore()
   })
 
+  it('resets when isActive flips from inactive to active while in error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { rerender } = render(
+      <ErrorBoundary isActive={true}>
+        <AlwaysThrows />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+
+    rerender(
+      <ErrorBoundary isActive={false}>
+        <div>recovered</div>
+      </ErrorBoundary>
+    )
+    rerender(
+      <ErrorBoundary isActive={true}>
+        <div>recovered</div>
+      </ErrorBoundary>
+    )
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    spy.mockRestore()
+  })
+
+  it('does not reset while isActive stays false', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { rerender } = render(
+      <ErrorBoundary isActive={true}>
+        <AlwaysThrows />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+
+    rerender(
+      <ErrorBoundary isActive={false}>
+        <div>recovered</div>
+      </ErrorBoundary>
+    )
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+    spy.mockRestore()
+  })
+
   it('logs error with component name to console', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     render(

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { ErrorBoundary } from './ErrorBoundary'
+
+function Thrower({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test error message')
+  }
+  return <div>content</div>
+}
+
+function AlwaysThrows() {
+  throw new Error('Component crashed')
+}
+
+describe('error boundary', () => {
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>content</div>
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('content')).toBeTruthy()
+  })
+
+  it('shows fallback UI on render error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <ErrorBoundary>
+        <Thrower shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+    expect(screen.getByText('Test error message')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy()
+    spy.mockRestore()
+  })
+
+  it('shows section name in fallback when name prop provided', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <ErrorBoundary name="Dashboard">
+        <Thrower shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('in Dashboard')).toBeTruthy()
+    spy.mockRestore()
+  })
+
+  it('resets to children after try again click', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { rerender } = render(
+      <ErrorBoundary>
+        <AlwaysThrows />
+      </ErrorBoundary>
+    )
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+
+    rerender(
+      <ErrorBoundary>
+        <div>recovered</div>
+      </ErrorBoundary>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    spy.mockRestore()
+  })
+
+  it('logs error with component name to console', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <ErrorBoundary name="Import">
+        <Thrower shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(spy).toHaveBeenCalledWith(
+      '[ErrorBoundary (Import)]',
+      expect.any(Error),
+      expect.anything()
+    )
+    spy.mockRestore()
+  })
+})

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, useCallback, useState } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  name?: string
+}
+
+interface BoundaryState {
+  hasError: boolean
+  error: Error | undefined
+}
+
+interface BoundaryInnerProps {
+  children: ReactNode
+  name?: string
+  onReset: () => void
+}
+
+class ErrorBoundaryInner extends Component<BoundaryInnerProps, BoundaryState> {
+  constructor(props: BoundaryInnerProps) {
+    super(props)
+    this.state = { error: undefined, hasError: false }
+  }
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { error, hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const label = this.props.name ? ` (${this.props.name})` : ''
+    console.error(`[ErrorBoundary${label}]`, error, info.componentStack)
+  }
+
+  render() {
+    const { error, hasError } = this.state
+    return hasError && error ? (
+      <div className="error-boundary-fallback">
+        <h2 className="error-boundary-title">Something went wrong</h2>
+        {this.props.name && <p className="error-boundary-section">in {this.props.name}</p>}
+        <p className="error-boundary-message">{error.message}</p>
+        <button type="button" className="error-boundary-reset" onClick={this.props.onReset}>
+          Try again
+        </button>
+      </div>
+    ) : (
+      this.props.children
+    )
+  }
+}
+
+export function ErrorBoundary({ children, name }: ErrorBoundaryProps) {
+  const [resetKey, setResetKey] = useState(0)
+  const handleReset = useCallback(() => setResetKey((k) => k + 1), [])
+  return (
+    <ErrorBoundaryInner key={resetKey} name={name} onReset={handleReset}>
+      {children}
+    </ErrorBoundaryInner>
+  )
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,9 +1,10 @@
-import { Component, useCallback, useState } from 'react'
+import { Component, useCallback, useEffect, useRef, useState } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 
 interface ErrorBoundaryProps {
   children: ReactNode
   name?: string
+  isActive?: boolean
 }
 
 interface BoundaryState {
@@ -15,6 +16,7 @@ interface BoundaryInnerProps {
   children: ReactNode
   name?: string
   onReset: () => void
+  onError: () => void
 }
 
 class ErrorBoundaryInner extends Component<BoundaryInnerProps, BoundaryState> {
@@ -28,6 +30,7 @@ class ErrorBoundaryInner extends Component<BoundaryInnerProps, BoundaryState> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError()
     const label = this.props.name ? ` (${this.props.name})` : ''
     console.error(`[ErrorBoundary${label}]`, error, info.componentStack)
   }
@@ -49,11 +52,30 @@ class ErrorBoundaryInner extends Component<BoundaryInnerProps, BoundaryState> {
   }
 }
 
-export function ErrorBoundary({ children, name }: ErrorBoundaryProps) {
+export function ErrorBoundary({ children, name, isActive }: ErrorBoundaryProps) {
   const [resetKey, setResetKey] = useState(0)
-  const handleReset = useCallback(() => setResetKey((k) => k + 1), [])
+  const hasErrorRef = useRef(false)
+  const prevIsActiveRef = useRef(isActive)
+
+  const handleReset = useCallback(() => {
+    hasErrorRef.current = false
+    setResetKey((k) => k + 1)
+  }, [])
+
+  const handleError = useCallback(() => {
+    hasErrorRef.current = true
+  }, [])
+
+  useEffect(() => {
+    if (isActive && !prevIsActiveRef.current && hasErrorRef.current) {
+      hasErrorRef.current = false
+      setResetKey((k) => k + 1)
+    }
+    prevIsActiveRef.current = isActive
+  }, [isActive])
+
   return (
-    <ErrorBoundaryInner key={resetKey} name={name} onReset={handleReset}>
+    <ErrorBoundaryInner key={resetKey} name={name} onReset={handleReset} onError={handleError}>
       {children}
     </ErrorBoundaryInner>
   )

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1983,3 +1983,60 @@ input[type='checkbox'] + label {
     transform: translateY(0);
   }
 }
+
+/* Error Boundary */
+
+.error-boundary-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  padding: var(--space-xl);
+  text-align: center;
+}
+
+.error-boundary-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-xs);
+}
+
+.error-boundary-section {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  margin-bottom: var(--space-md);
+}
+
+.error-boundary-message {
+  font-size: var(--font-size-md);
+  color: var(--color-error);
+  margin-bottom: var(--space-xl);
+  padding: var(--space-md);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  border-radius: var(--radius-md);
+  word-break: break-word;
+  max-width: 400px;
+}
+
+.error-boundary-reset {
+  padding: var(--space-xs) var(--space-xl);
+  background: var(--color-accent-primary);
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.error-boundary-reset:hover {
+  background: var(--color-hover);
+}
+
+.error-boundary-reset:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -264,3 +264,13 @@ a:hover {
   color: var(--color-text-tertiary);
   line-height: var(--line-height-base);
 }
+
+/* View visibility utilities */
+
+.view-hidden {
+  display: none;
+}
+
+.view-active {
+  display: block;
+}


### PR DESCRIPTION
## Motivation

App had no error boundaries — any thrown component error caused a full white-screen crash with no recovery path. Listed in CLAUDE.md known debt.

## Implementation information

- Added `ErrorBoundary` component with `getDerivedStateFromError` lifecycle, fallback UI, and a retry action
- Wrapped each top-level view in `App.tsx` with its own `ErrorBoundary` so failures are isolated per view
- Reset boundary state (`resetError`) when the active view changes so switching views clears stale error state

Closes https://github.com/Automaat/creatorops/issues/159