### PR TITLE
refactor(frontend): replace console with NotificationContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { NotificationToast } from './components/NotificationToast'
 import { Projects } from './components/Projects'
 import { Settings } from './components/Settings'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { useNotification } from './hooks/useNotification'
 import { useSDCardScanner } from './hooks/useSDCardScanner'
 import { useTheme } from './hooks/useTheme'
 import type { Project } from './types'
@@ -53,6 +54,8 @@ function App() {
   const [viewBeforeProject, setViewBeforeProject] = useState<View>('dashboard')
   const [projectsResetKey, setProjectsResetKey] = useState<number>(0)
 
+  const { error: showError } = useNotification()
+
   // Apply theme on app load
   useTheme()
 
@@ -63,6 +66,7 @@ function App() {
       setProjectsCount(projects.length)
     } catch (error) {
       console.error('Failed to load project count:', error)
+      showError('Failed to load project count')
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 
@@ -60,7 +60,7 @@ function App() {
   useTheme()
 
   // Load and refresh project count for badge
-  const loadProjectCount = async () => {
+  const loadProjectCount = useCallback(async () => {
     try {
       const projects = await invoke<Project[]>('list_projects')
       setProjectsCount(projects.length)
@@ -68,11 +68,11 @@ function App() {
       console.error('Failed to load project count:', error)
       showError('Failed to load project count')
     }
-  }
+  }, [showError])
 
   useEffect(() => {
     void loadProjectCount()
-  }, [])
+  }, [loadProjectCount])
 
   // Global SD card scanner - runs in background across all pages
   const { sdCards, isScanning, scanForSDCards } = useSDCardScanner({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,7 +188,10 @@ function App() {
         projectsCount={projectsCount}
       >
         <ViewWrapper isActive={currentView === 'dashboard'} name="Dashboard">
-          <Dashboard isActive={currentView === 'dashboard'} onProjectClick={handleNavigateToProject} />
+          <Dashboard
+            isActive={currentView === 'dashboard'}
+            onProjectClick={handleNavigateToProject}
+          />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'import'} name="Import">
           <Import

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,7 +188,7 @@ function App() {
         projectsCount={projectsCount}
       >
         <ViewWrapper isActive={currentView === 'dashboard'} name="Dashboard">
-          <Dashboard onProjectClick={handleNavigateToProject} />
+          <Dashboard isActive={currentView === 'dashboard'} onProjectClick={handleNavigateToProject} />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'import'} name="Import">
           <Import
@@ -201,20 +201,21 @@ function App() {
           <Projects
             key={`${selectedProjectId ?? 'projects-list'}-${projectsResetKey}`}
             initialSelectedProjectId={selectedProjectId}
+            isActive={currentView === 'projects'}
             onBackFromProject={handleBackFromProject}
           />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'backup'} name="Backup Queue">
-          <BackupQueue />
+          <BackupQueue isActive={currentView === 'backup'} />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'delivery'} name="Delivery">
-          <Delivery />
+          <Delivery isActive={currentView === 'delivery'} />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'history'} name="History">
           <History />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'settings'} name="Settings">
-          <Settings />
+          <Settings isActive={currentView === 'settings'} />
         </ViewWrapper>
       </Layout>
       <NotificationToast />

--- a/src/components/BackupQueue.tsx
+++ b/src/components/BackupQueue.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { formatBytes, formatETA, formatSpeed } from '../utils/formatting'
@@ -21,6 +21,20 @@ export function BackupQueue({ isActive }: BackupQueueProps) {
   const [jobs, setJobs] = useState<BackupJob[]>([])
   const [progress, setProgress] = useState<Map<string, BackupProgress>>(new Map())
 
+  const loadQueue = useCallback(async () => {
+    try {
+      const data = await invoke<BackupJob[]>('get_backup_queue')
+      setJobs(data)
+      hasShownQueueError.current = false
+    } catch (error) {
+      console.error('Failed to load backup queue:', error)
+      if (isActiveRef.current && !hasShownQueueError.current) {
+        showError('Failed to load backup queue')
+        hasShownQueueError.current = true
+      }
+    }
+  }, [showError])
+
   useEffect(() => {
     void loadQueue()
 
@@ -40,21 +54,7 @@ export function BackupQueue({ isActive }: BackupQueueProps) {
       void unlistenJobUpdate.then((fn) => fn()).catch(() => {})
       clearInterval(interval)
     }
-  }, [])
-
-  async function loadQueue() {
-    try {
-      const data = await invoke<BackupJob[]>('get_backup_queue')
-      setJobs(data)
-      hasShownQueueError.current = false
-    } catch (error) {
-      console.error('Failed to load backup queue:', error)
-      if (isActiveRef.current && !hasShownQueueError.current) {
-        showError('Failed to load backup queue')
-        hasShownQueueError.current = true
-      }
-    }
-  }
+  }, [loadQueue])
 
   async function startBackup(jobId: string) {
     try {

--- a/src/components/BackupQueue.tsx
+++ b/src/components/BackupQueue.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { formatBytes, formatETA, formatSpeed } from '../utils/formatting'
+import { useNotification } from '../hooks/useNotification'
 import type { BackupJob, BackupProgress } from '../types'
 
 const QUEUE_REFRESH_INTERVAL = 30_000
 
 export function BackupQueue() {
+  const { error: showError } = useNotification()
   const [jobs, setJobs] = useState<BackupJob[]>([])
   const [progress, setProgress] = useState<Map<string, BackupProgress>>(new Map())
 
@@ -37,6 +39,7 @@ export function BackupQueue() {
       setJobs(data)
     } catch (error) {
       console.error('Failed to load backup queue:', error)
+      showError('Failed to load backup queue')
     }
   }
 
@@ -46,6 +49,7 @@ export function BackupQueue() {
       await loadQueue()
     } catch (error) {
       console.error('Failed to start backup:', error)
+      showError('Failed to start backup')
     }
   }
 
@@ -55,6 +59,7 @@ export function BackupQueue() {
       await loadQueue()
     } catch (error) {
       console.error('Failed to cancel backup:', error)
+      showError('Failed to cancel backup')
     }
   }
 
@@ -64,6 +69,7 @@ export function BackupQueue() {
       await loadQueue()
     } catch (error) {
       console.error('Failed to remove job:', error)
+      showError('Failed to remove job')
     }
   }
 

--- a/src/components/BackupQueue.tsx
+++ b/src/components/BackupQueue.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { formatBytes, formatETA, formatSpeed } from '../utils/formatting'
@@ -7,8 +7,17 @@ import type { BackupJob, BackupProgress } from '../types'
 
 const QUEUE_REFRESH_INTERVAL = 30_000
 
-export function BackupQueue() {
+interface BackupQueueProps {
+  isActive?: boolean
+}
+
+export function BackupQueue({ isActive }: BackupQueueProps) {
   const { error: showError } = useNotification()
+  const isActiveRef = useRef(isActive ?? false)
+  useEffect(() => {
+    isActiveRef.current = isActive ?? false
+  }, [isActive])
+  const hasShownQueueError = useRef(false)
   const [jobs, setJobs] = useState<BackupJob[]>([])
   const [progress, setProgress] = useState<Map<string, BackupProgress>>(new Map())
 
@@ -37,9 +46,13 @@ export function BackupQueue() {
     try {
       const data = await invoke<BackupJob[]>('get_backup_queue')
       setJobs(data)
+      hasShownQueueError.current = false
     } catch (error) {
       console.error('Failed to load backup queue:', error)
-      showError('Failed to load backup queue')
+      if (isActiveRef.current && !hasShownQueueError.current) {
+        showError('Failed to load backup queue')
+        hasShownQueueError.current = true
+      }
     }
   }
 

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -10,6 +10,18 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }))
 
+vi.mock('../hooks/useNotification', () => ({
+  useNotification: () => ({
+    addNotification: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    notifications: [],
+    removeNotification: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  }),
+}))
+
 const mockInvoke = vi.mocked(invoke)
 
 // Mock scrollIntoView

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -10,17 +10,18 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }))
 
-vi.mock('../hooks/useNotification', () => ({
-  useNotification: () => ({
+vi.mock('../hooks/useNotification', () => {
+  const notification = {
     addNotification: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
-    notifications: [],
+    notifications: [] as never[],
     removeNotification: vi.fn(),
     success: vi.fn(),
     warning: vi.fn(),
-  }),
-}))
+  }
+  return { useNotification: () => notification }
+})
 
 const mockInvoke = vi.mocked(invoke)
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -17,6 +17,16 @@ export function CommandPalette({ isOpen, onClose, onSelectProject }: CommandPale
   const inputRef = useRef<HTMLInputElement>(null)
   const selectedItemRef = useRef<HTMLDivElement>(null)
 
+  const loadProjects = useCallback(async () => {
+    try {
+      const projectList = await invoke<Project[]>('list_projects')
+      setProjects(projectList)
+    } catch (error) {
+      console.error('Failed to load projects:', error)
+      showError('Failed to load projects')
+    }
+  }, [showError])
+
   useEffect(() => {
     if (isOpen) {
       void loadProjects()
@@ -25,17 +35,7 @@ export function CommandPalette({ isOpen, onClose, onSelectProject }: CommandPale
       // Focus input after render
       setTimeout(() => inputRef.current?.focus(), 0)
     }
-  }, [isOpen])
-
-  const loadProjects = async () => {
-    try {
-      const projectList = await invoke<Project[]>('list_projects')
-      setProjects(projectList)
-    } catch (error) {
-      console.error('Failed to load projects:', error)
-      showError('Failed to load projects')
-    }
-  }
+  }, [isOpen, loadProjects])
 
   const filteredProjects = projects.filter((project) => {
     const query = searchQuery.toLowerCase()

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
+import { useNotification } from '../hooks/useNotification'
 import type { Project } from '../types'
 
 interface CommandPaletteProps {
@@ -9,6 +10,7 @@ interface CommandPaletteProps {
 }
 
 export function CommandPalette({ isOpen, onClose, onSelectProject }: CommandPaletteProps) {
+  const { error: showError } = useNotification()
   const [projects, setProjects] = useState<Project[]>([])
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -31,6 +33,7 @@ export function CommandPalette({ isOpen, onClose, onSelectProject }: CommandPale
       setProjects(projectList)
     } catch (error) {
       console.error('Failed to load projects:', error)
+      showError('Failed to load projects')
     }
   }
 

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -11,6 +11,18 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }))
 
+vi.mock('../hooks/useNotification', () => ({
+  useNotification: () => ({
+    addNotification: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    notifications: [],
+    removeNotification: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  }),
+}))
+
 const mockInvoke = vi.mocked(invoke)
 // Mock CreateProject component
 vi.mock('./CreateProject', () => ({

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { ProjectStatus } from '../types'
 import type { Project } from '../types'
@@ -22,11 +22,7 @@ export function Dashboard({ isActive, onProjectClick }: DashboardProps) {
   const [loading, setLoading] = useState(true)
   const [showCreateProject, setShowCreateProject] = useState(false)
 
-  useEffect(() => {
-    void loadData()
-  }, [])
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true)
       const projectList = await invoke<Project[]>('list_projects')
@@ -37,7 +33,11 @@ export function Dashboard({ isActive, onProjectClick }: DashboardProps) {
     } finally {
       setLoading(false)
     }
-  }
+  }, [showError])
+
+  useEffect(() => {
+    void loadData()
+  }, [loadData])
 
   function getStatusColor(status: string): string {
     switch (status) {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { ProjectStatus } from '../types'
 import type { Project } from '../types'
 import { isOverdue, sortProjects } from '../utils/project'
 import { formatDisplayDate } from '../utils/formatting'
+import { useNotification } from '../hooks/useNotification'
 import { CreateProject } from './CreateProject'
 
 interface DashboardProps {
@@ -11,6 +12,7 @@ interface DashboardProps {
 }
 
 export function Dashboard({ onProjectClick }: DashboardProps) {
+  const { error: showError } = useNotification()
   const [projects, setProjects] = useState<Project[]>([])
   const [loading, setLoading] = useState(true)
   const [showCreateProject, setShowCreateProject] = useState(false)
@@ -26,6 +28,7 @@ export function Dashboard({ onProjectClick }: DashboardProps) {
       setProjects(projectList)
     } catch (error) {
       console.error('Failed to load dashboard data:', error)
+      showError('Failed to load dashboard data')
     } finally {
       setLoading(false)
     }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { ProjectStatus } from '../types'
 import type { Project } from '../types'
@@ -8,11 +8,16 @@ import { useNotification } from '../hooks/useNotification'
 import { CreateProject } from './CreateProject'
 
 interface DashboardProps {
+  isActive?: boolean
   onProjectClick?: (projectId: string) => void
 }
 
-export function Dashboard({ onProjectClick }: DashboardProps) {
+export function Dashboard({ isActive, onProjectClick }: DashboardProps) {
   const { error: showError } = useNotification()
+  const isActiveRef = useRef(isActive ?? false)
+  useEffect(() => {
+    isActiveRef.current = isActive ?? false
+  }, [isActive])
   const [projects, setProjects] = useState<Project[]>([])
   const [loading, setLoading] = useState(true)
   const [showCreateProject, setShowCreateProject] = useState(false)
@@ -28,7 +33,7 @@ export function Dashboard({ onProjectClick }: DashboardProps) {
       setProjects(projectList)
     } catch (error) {
       console.error('Failed to load dashboard data:', error)
-      showError('Failed to load dashboard data')
+      if (isActiveRef.current) showError('Failed to load dashboard data')
     } finally {
       setLoading(false)
     }

--- a/src/components/Delivery.tsx
+++ b/src/components/Delivery.tsx
@@ -79,16 +79,19 @@ export function Delivery({ isActive }: DeliveryProps) {
     }
   }, [showError])
 
-  const loadProjectFiles = useCallback(async (projectId: string) => {
-    try {
-      const files = await invoke<ProjectFile[]>('list_project_files', { projectId })
-      setProjectFiles(files)
-      setSelectedFiles(new Set())
-    } catch (error) {
-      console.error('Failed to load project files:', error)
-      showError('Failed to load project files')
-    }
-  }, [showError])
+  const loadProjectFiles = useCallback(
+    async (projectId: string) => {
+      try {
+        const files = await invoke<ProjectFile[]>('list_project_files', { projectId })
+        setProjectFiles(files)
+        setSelectedFiles(new Set())
+      } catch (error) {
+        console.error('Failed to load project files:', error)
+        showError('Failed to load project files')
+      }
+    },
+    [showError]
+  )
 
   useEffect(() => {
     void loadProjects()

--- a/src/components/Delivery.tsx
+++ b/src/components/Delivery.tsx
@@ -33,9 +33,9 @@ export function Delivery() {
   const dropdownRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    loadProjects().catch(console.error)
+    void loadProjects()
     loadDestinations()
-    loadDeliveryQueue().catch(console.error)
+    void loadDeliveryQueue()
 
     const unlistenDelivery = listen<DeliveryProgress>('delivery-progress', (event) => {
       const progress = event.payload
@@ -127,6 +127,7 @@ export function Delivery() {
       setProjects(sortedProjects)
     } catch (error) {
       console.error('Failed to load projects:', error)
+      showError('Failed to load projects')
     } finally {
       setLoading(false)
     }
@@ -139,6 +140,7 @@ export function Delivery() {
       setSelectedFiles(new Set())
     } catch (error) {
       console.error('Failed to load project files:', error)
+      showError('Failed to load project files')
     }
   }
 
@@ -153,6 +155,7 @@ export function Delivery() {
       }
     } catch (error) {
       console.error('Failed to load destinations:', error)
+      showError('Failed to load destinations')
     }
   }
 
@@ -162,6 +165,7 @@ export function Delivery() {
       setDeliveryJobs(queue)
     } catch (error) {
       console.error('Failed to load delivery queue:', error)
+      showError('Failed to load delivery queue')
     }
   }
 
@@ -215,6 +219,7 @@ export function Delivery() {
       setDeliveryJobs((prev) => [...prev, job])
     } catch (error) {
       console.error('Failed to create delivery:', error)
+      showError('Failed to create delivery')
     }
   }
 
@@ -224,6 +229,7 @@ export function Delivery() {
       setDeliveryJobs((prev) => prev.filter((j) => j.id !== jobId))
     } catch (error) {
       console.error('Failed to remove job:', error)
+      showError('Failed to remove job')
     }
   }
 

--- a/src/components/Delivery.tsx
+++ b/src/components/Delivery.tsx
@@ -13,8 +13,16 @@ import type {
   ProjectFile,
 } from '../types'
 
-export function Delivery() {
+interface DeliveryProps {
+  isActive?: boolean
+}
+
+export function Delivery({ isActive }: DeliveryProps) {
   const { error: showError, success: showSuccess } = useNotification()
+  const isActiveRef = useRef(isActive ?? false)
+  useEffect(() => {
+    isActiveRef.current = isActive ?? false
+  }, [isActive])
   const [projects, setProjects] = useState<Project[]>([])
   const [selectedProject, setSelectedProject] = useState<Project | null>()
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([])
@@ -127,7 +135,7 @@ export function Delivery() {
       setProjects(sortedProjects)
     } catch (error) {
       console.error('Failed to load projects:', error)
-      showError('Failed to load projects')
+      if (isActiveRef.current) showError('Failed to load projects')
     } finally {
       setLoading(false)
     }
@@ -155,7 +163,7 @@ export function Delivery() {
       }
     } catch (error) {
       console.error('Failed to load destinations:', error)
-      showError('Failed to load destinations')
+      if (isActiveRef.current) showError('Failed to load destinations')
     }
   }
 
@@ -165,7 +173,7 @@ export function Delivery() {
       setDeliveryJobs(queue)
     } catch (error) {
       console.error('Failed to load delivery queue:', error)
-      showError('Failed to load delivery queue')
+      if (isActiveRef.current) showError('Failed to load delivery queue')
     }
   }
 

--- a/src/components/Delivery.tsx
+++ b/src/components/Delivery.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { formatBytes } from '../utils/formatting'
@@ -40,6 +40,56 @@ export function Delivery({ isActive }: DeliveryProps) {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
+  const loadProjects = useCallback(async () => {
+    try {
+      setLoading(true)
+      const data = await invoke<Project[]>('list_projects')
+      const sortedProjects = sortProjectsByStatus(data)
+      setProjects(sortedProjects)
+    } catch (error) {
+      console.error('Failed to load projects:', error)
+      if (isActiveRef.current) showError('Failed to load projects')
+    } finally {
+      setLoading(false)
+    }
+  }, [showError])
+
+  const loadDestinations = useCallback(() => {
+    try {
+      const stored = localStorage.getItem('delivery_destinations')
+      if (stored) {
+        const parsed: unknown = JSON.parse(stored)
+        const migrated = migrateDeliveryDestinations(parsed)
+        localStorage.setItem('delivery_destinations', JSON.stringify(migrated))
+        setDestinations(migrated)
+      }
+    } catch (error) {
+      console.error('Failed to load destinations:', error)
+      if (isActiveRef.current) showError('Failed to load destinations')
+    }
+  }, [showError])
+
+  const loadDeliveryQueue = useCallback(async () => {
+    try {
+      const queue = await invoke<DeliveryJob[]>('get_delivery_queue')
+      setDeliveryJobs(queue)
+    } catch (error) {
+      console.error('Failed to load delivery queue:', error)
+      if (isActiveRef.current) showError('Failed to load delivery queue')
+    }
+  }, [showError])
+
+  const loadProjectFiles = useCallback(async (projectId: string) => {
+    try {
+      const files = await invoke<ProjectFile[]>('list_project_files', { projectId })
+      setProjectFiles(files)
+      setSelectedFiles(new Set())
+    } catch (error) {
+      console.error('Failed to load project files:', error)
+      showError('Failed to load project files')
+    }
+  }, [showError])
+
   useEffect(() => {
     void loadProjects()
     loadDestinations()
@@ -79,13 +129,13 @@ export function Delivery({ isActive }: DeliveryProps) {
       void unlistenDelivery.then((fn) => fn()).catch(() => {})
       void unlistenDrive.then((fn) => fn()).catch(() => {})
     }
-  }, [])
+  }, [loadProjects, loadDestinations, loadDeliveryQueue])
 
   useEffect(() => {
     if (selectedProject) {
       void loadProjectFiles(selectedProject.id)
     }
-  }, [selectedProject])
+  }, [selectedProject, loadProjectFiles])
 
   useEffect(() => {
     if (showProjectSelect) {
@@ -124,56 +174,6 @@ export function Delivery({ isActive }: DeliveryProps) {
         top: rect.bottom + 8,
         width: rect.width,
       })
-    }
-  }
-
-  async function loadProjects() {
-    try {
-      setLoading(true)
-      const data = await invoke<Project[]>('list_projects')
-      const sortedProjects = sortProjectsByStatus(data)
-      setProjects(sortedProjects)
-    } catch (error) {
-      console.error('Failed to load projects:', error)
-      if (isActiveRef.current) showError('Failed to load projects')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function loadProjectFiles(projectId: string) {
-    try {
-      const files = await invoke<ProjectFile[]>('list_project_files', { projectId })
-      setProjectFiles(files)
-      setSelectedFiles(new Set())
-    } catch (error) {
-      console.error('Failed to load project files:', error)
-      showError('Failed to load project files')
-    }
-  }
-
-  function loadDestinations() {
-    try {
-      const stored = localStorage.getItem('delivery_destinations')
-      if (stored) {
-        const parsed: unknown = JSON.parse(stored)
-        const migrated = migrateDeliveryDestinations(parsed)
-        localStorage.setItem('delivery_destinations', JSON.stringify(migrated))
-        setDestinations(migrated)
-      }
-    } catch (error) {
-      console.error('Failed to load destinations:', error)
-      if (isActiveRef.current) showError('Failed to load destinations')
-    }
-  }
-
-  async function loadDeliveryQueue() {
-    try {
-      const queue = await invoke<DeliveryJob[]>('get_delivery_queue')
-      setDeliveryJobs(queue)
-    } catch (error) {
-      console.error('Failed to load delivery queue:', error)
-      if (isActiveRef.current) showError('Failed to load delivery queue')
     }
   }
 

--- a/src/components/Import.tsx
+++ b/src/components/Import.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import type { CopyResult, ImportProgress, Project, SDCard } from '../types'
 import { ProjectStatus } from '../types'
+import { useNotification } from '../hooks/useNotification'
 import { CreateProject } from './CreateProject'
 import { sortProjectsByStatus } from '../utils/project'
 
@@ -93,6 +94,7 @@ function SDCardItem({
   onActivate,
   onDeactivate,
 }: SDCardItemProps) {
+  const { error: showError, warning: showWarning } = useNotification()
   const [showProjectSelect, setShowProjectSelect] = useState(false)
   const [projects, setProjects] = useState<Project[]>([])
   const [selectedProject, setSelectedProject] = useState<string>('')
@@ -139,8 +141,9 @@ function SDCardItem({
       setProjects(sortedProjects)
     } catch (error) {
       console.error('Failed to load projects:', error)
+      showError('Failed to load projects')
     }
-  }, [])
+  }, [showError])
 
   const updateDropdownPosition = () => {
     if (triggerRef.current) {
@@ -326,6 +329,7 @@ function SDCardItem({
             await invoke('eject_sd_card', { volumePath: card.path })
           } catch (error) {
             console.error('Failed to eject SD card:', error)
+            showWarning('Failed to eject SD card')
           }
         }
 
@@ -333,6 +337,7 @@ function SDCardItem({
       }
     } catch (error) {
       console.error('Import failed:', error)
+      showError('Import failed')
       setImportResult({
         error: String(error),
         filesCopied: 0,
@@ -361,6 +366,7 @@ function SDCardItem({
         })
       } catch (error) {
         console.error('Failed to save import history:', error)
+        showError('Failed to save import history')
       }
     } finally {
       setIsImporting(false)
@@ -377,6 +383,7 @@ function SDCardItem({
       await invoke('cancel_import', { importId })
     } catch (error) {
       console.error('Failed to cancel import:', error)
+      showError('Failed to cancel import')
     }
   }
 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -80,6 +80,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       return data
     } catch (error) {
       console.error('Failed to load projects:', error)
+      showError('Failed to load projects')
       return []
     } finally {
       setLoading(false)
@@ -87,10 +88,10 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
   }, [])
 
   useEffect(() => {
-    loadProjects().catch(console.error)
+    void loadProjects()
     loadDestinations()
     loadArchiveLocation()
-    loadHomeDirectory().catch(console.error)
+    void loadHomeDirectory()
   }, [loadProjects])
 
   async function loadHomeDirectory() {
@@ -99,6 +100,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       setHomeDir(dir)
     } catch (error) {
       console.error('Failed to load home directory:', error)
+      showError('Failed to load home directory')
     }
   }
 
@@ -114,6 +116,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
         })
         .catch((error: unknown) => {
           console.error('Failed to load project:', error)
+          showError('Failed to load project')
         })
     } else {
       // Clear selection when navigating to projects list
@@ -193,6 +196,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       }
     } catch (error) {
       console.error('Failed to load destinations:', error)
+      showError('Failed to load destinations')
     }
   }
 
@@ -204,6 +208,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       }
     } catch (error) {
       console.error('Failed to load archive location:', error)
+      showError('Failed to load archive location')
     }
   }
 
@@ -213,6 +218,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       setImportHistory(history)
     } catch (error) {
       console.error('Failed to load import history:', error)
+      showError('Failed to load import history')
     }
   }
 
@@ -228,6 +234,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       })
     } catch (error) {
       console.error('Failed to queue backup:', error)
+      showError('Failed to queue backup')
     }
   }
 
@@ -441,6 +448,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       }
     } catch (error) {
       console.error('Import failed:', error)
+      showError('Import failed')
       setImportResult(createEmptyResult(String(error)))
 
       try {
@@ -459,6 +467,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
         })
       } catch (error) {
         console.error('Failed to save import history:', error)
+        showError('Failed to save import history')
       }
     } finally {
       setIsImporting(false)
@@ -475,6 +484,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       await invoke('cancel_import', { importId })
     } catch (error) {
       console.error('Failed to cancel import:', error)
+      showError('Failed to cancel import')
     }
   }
 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -90,16 +90,9 @@ export function Projects({ initialSelectedProjectId, isActive, onBackFromProject
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [showError])
 
-  useEffect(() => {
-    void loadProjects()
-    loadDestinations()
-    loadArchiveLocation()
-    void loadHomeDirectory()
-  }, [loadProjects])
-
-  async function loadHomeDirectory() {
+  const loadHomeDirectory = useCallback(async () => {
     try {
       const dir = await invoke<string>('get_home_directory')
       setHomeDir(dir)
@@ -107,7 +100,61 @@ export function Projects({ initialSelectedProjectId, isActive, onBackFromProject
       console.error('Failed to load home directory:', error)
       if (isActiveRef.current) showError('Failed to load home directory')
     }
-  }
+  }, [showError])
+
+  const loadDestinations = useCallback(() => {
+    try {
+      const stored = localStorage.getItem('backup_destinations')
+      if (stored) {
+        const parsed: unknown = JSON.parse(stored)
+        if (
+          Array.isArray(parsed) &&
+          parsed.every(
+            (item): item is BackupDestination =>
+              typeof item === 'object' &&
+              item !== null &&
+              'id' in item &&
+              'name' in item &&
+              'path' in item
+          )
+        ) {
+          setDestinations(parsed)
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load destinations:', error)
+      showError('Failed to load destinations')
+    }
+  }, [showError])
+
+  const loadArchiveLocation = useCallback(() => {
+    try {
+      const stored = localStorage.getItem('archive_location')
+      if (stored) {
+        setArchiveLocation(stored)
+      }
+    } catch (error) {
+      console.error('Failed to load archive location:', error)
+      showError('Failed to load archive location')
+    }
+  }, [showError])
+
+  const loadProjectImportHistory = useCallback(async (projectId: string) => {
+    try {
+      const history = await invoke<ImportHistory[]>('get_project_import_history', { projectId })
+      setImportHistory(history)
+    } catch (error) {
+      console.error('Failed to load import history:', error)
+      showError('Failed to load import history')
+    }
+  }, [showError])
+
+  useEffect(() => {
+    void loadProjects()
+    loadDestinations()
+    loadArchiveLocation()
+    void loadHomeDirectory()
+  }, [loadProjects, loadDestinations, loadArchiveLocation, loadHomeDirectory])
 
   // Handle initial project selection from navigation
   useEffect(() => {
@@ -127,7 +174,7 @@ export function Projects({ initialSelectedProjectId, isActive, onBackFromProject
       // Clear selection when navigating to projects list
       setSelectedProject(undefined)
     }
-  }, [initialSelectedProjectId])
+  }, [initialSelectedProjectId, showError])
 
   // Load import history when project is selected and scroll to top
   useEffect(() => {
@@ -135,7 +182,7 @@ export function Projects({ initialSelectedProjectId, isActive, onBackFromProject
       void loadProjectImportHistory(selectedProject.id)
       scrollToTop()
     }
-  }, [selectedProject, scrollToTop])
+  }, [selectedProject, scrollToTop, loadProjectImportHistory])
 
   const handleBackToList = useCallback(() => {
     // If internal selection (clicked from Projects list), just clear selection
@@ -179,53 +226,6 @@ export function Projects({ initialSelectedProjectId, isActive, onBackFromProject
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [selectedProject])
-
-  function loadDestinations() {
-    try {
-      const stored = localStorage.getItem('backup_destinations')
-      if (stored) {
-        const parsed: unknown = JSON.parse(stored)
-        if (
-          Array.isArray(parsed) &&
-          parsed.every(
-            (item): item is BackupDestination =>
-              typeof item === 'object' &&
-              item !== null &&
-              'id' in item &&
-              'name' in item &&
-              'path' in item
-          )
-        ) {
-          setDestinations(parsed)
-        }
-      }
-    } catch (error) {
-      console.error('Failed to load destinations:', error)
-      showError('Failed to load destinations')
-    }
-  }
-
-  function loadArchiveLocation() {
-    try {
-      const stored = localStorage.getItem('archive_location')
-      if (stored) {
-        setArchiveLocation(stored)
-      }
-    } catch (error) {
-      console.error('Failed to load archive location:', error)
-      showError('Failed to load archive location')
-    }
-  }
-
-  async function loadProjectImportHistory(projectId: string) {
-    try {
-      const history = await invoke<ImportHistory[]>('get_project_import_history', { projectId })
-      setImportHistory(history)
-    } catch (error) {
-      console.error('Failed to load import history:', error)
-      showError('Failed to load import history')
-    }
-  }
 
   async function queueBackup(project: Project, destination: BackupDestination) {
     try {

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -139,15 +139,18 @@ export function Projects({ initialSelectedProjectId, isActive, onBackFromProject
     }
   }, [showError])
 
-  const loadProjectImportHistory = useCallback(async (projectId: string) => {
-    try {
-      const history = await invoke<ImportHistory[]>('get_project_import_history', { projectId })
-      setImportHistory(history)
-    } catch (error) {
-      console.error('Failed to load import history:', error)
-      showError('Failed to load import history')
-    }
-  }, [showError])
+  const loadProjectImportHistory = useCallback(
+    async (projectId: string) => {
+      try {
+        const history = await invoke<ImportHistory[]>('get_project_import_history', { projectId })
+        setImportHistory(history)
+      } catch (error) {
+        console.error('Failed to load import history:', error)
+        showError('Failed to load import history')
+      }
+    },
+    [showError]
+  )
 
   useEffect(() => {
     void loadProjects()

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -19,10 +19,11 @@ import folderIcon from '../assets/icons/dir_selected.png'
 
 interface ProjectsProps {
   initialSelectedProjectId?: string | null
+  isActive?: boolean
   onBackFromProject?: () => void
 }
 
-export function Projects({ initialSelectedProjectId, onBackFromProject }: ProjectsProps) {
+export function Projects({ initialSelectedProjectId, isActive, onBackFromProject }: ProjectsProps) {
   const [projects, setProjects] = useState<Project[]>([])
   const [destinations, setDestinations] = useState<BackupDestination[]>([])
   const [selectedProject, setSelectedProject] = useState<Project | null>()
@@ -44,6 +45,10 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
   const containerRef = useRef<HTMLDivElement>(null)
   const { sdCards, isScanning } = useSDCardScanner()
   const { error: showError } = useNotification()
+  const isActiveRef = useRef(isActive ?? false)
+  useEffect(() => {
+    isActiveRef.current = isActive ?? false
+  }, [isActive])
 
   const replaceHomeWithTilde = (path: string): string => {
     if (!homeDir) {
@@ -80,7 +85,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       return data
     } catch (error) {
       console.error('Failed to load projects:', error)
-      showError('Failed to load projects')
+      if (isActiveRef.current) showError('Failed to load projects')
       return []
     } finally {
       setLoading(false)
@@ -100,7 +105,7 @@ export function Projects({ initialSelectedProjectId, onBackFromProject }: Projec
       setHomeDir(dir)
     } catch (error) {
       console.error('Failed to load home directory:', error)
-      showError('Failed to load home directory')
+      if (isActiveRef.current) showError('Failed to load home directory')
     }
   }
 

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Settings } from './Settings'
 import { NotificationProvider } from '../contexts/NotificationContext'
+import { NotificationToast } from './NotificationToast'
 import { open } from '@tauri-apps/plugin-dialog'
 
 // Mock Tauri API
@@ -79,12 +80,12 @@ describe('settings', () => {
   })
 
   it('does not add destination with empty name', async () => {
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const user = userEvent.setup()
 
     render(
       <NotificationProvider>
         <Settings />
+        <NotificationToast />
       </NotificationProvider>
     )
 
@@ -92,8 +93,9 @@ describe('settings', () => {
     await user.click(addButton)
 
     expect(mockOpen).not.toHaveBeenCalled()
-    expect(consoleWarn).toHaveBeenCalledWith('Destination name is required')
-    consoleWarn.mockRestore()
+    await waitFor(() => {
+      expect(screen.getByText('Destination name is required')).toBeTruthy()
+    })
   })
 
   it('toggles backup destination', async () => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -12,7 +12,7 @@ const DEFAULT_FILE_TEMPLATE = '{original}'
 
 export function Settings() {
   const { theme, setTheme } = useTheme()
-  const { error: showError, success: showSuccess } = useNotification()
+  const { error: showError, success: showSuccess, warning: showWarning } = useNotification()
   const [destinations, setDestinations] = useState<BackupDestination[]>([])
   const [newDestName, setNewDestName] = useState('')
   const [deliveryDestinations, setDeliveryDestinations] = useState<DeliveryDestination[]>([])
@@ -34,8 +34,9 @@ export function Settings() {
       setDriveAccount(account)
     } catch (error) {
       console.error('Failed to load Google Drive account:', error)
+      showError('Failed to load Google Drive account')
     }
-  }, [])
+  }, [showError])
 
   useEffect(() => {
     function loadDestinations() {
@@ -59,6 +60,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load destinations:', error)
+        showError('Failed to load destinations')
       }
     }
 
@@ -73,6 +75,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load delivery destinations:', error)
+        showError('Failed to load delivery destinations')
       }
     }
 
@@ -84,6 +87,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load default import location:', error)
+        showError('Failed to load default import location')
       }
     }
 
@@ -95,6 +99,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load archive location:', error)
+        showError('Failed to load archive location')
       }
     }
 
@@ -134,6 +139,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load conflict mode:', error)
+        showError('Failed to load drive conflict mode')
       }
     }
 
@@ -143,7 +149,7 @@ export function Settings() {
     loadArchiveLocation()
     loadTemplates()
     loadAutoEject()
-    loadDriveAccount().catch(console.error)
+    void loadDriveAccount()
     loadDriveConflictMode()
   }, [loadDriveAccount, showError])
 
@@ -154,7 +160,7 @@ export function Settings() {
 
   async function addDestination() {
     if (!newDestName.trim()) {
-      console.warn('Destination name is required')
+      showWarning('Destination name is required')
       return
     }
 
@@ -178,6 +184,7 @@ export function Settings() {
       }
     } catch (error) {
       console.error('Failed to add destination:', error)
+      showError('Failed to add destination')
     }
   }
 
@@ -221,6 +228,7 @@ export function Settings() {
       }
     } catch (error) {
       console.error('Failed to add delivery destination:', error)
+      showError('Failed to add delivery destination')
     }
   }
 
@@ -248,6 +256,7 @@ export function Settings() {
       }
     } catch (error) {
       console.error(`Failed to select ${storageKey}:`, error)
+      showError('Failed to select location')
     }
   }
 
@@ -291,6 +300,7 @@ export function Settings() {
       const { authUrl } = await invoke<{ authUrl: string }>('start_google_drive_auth')
       await openUrl(authUrl).catch((err: unknown) => {
         console.error('Failed to open auth URL:', err)
+        showError('Failed to open authentication URL')
       })
 
       // Poll for authentication completion

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { open } from '@tauri-apps/plugin-dialog'
 import { openUrl } from '@tauri-apps/plugin-opener'
@@ -10,9 +10,17 @@ import type { BackupDestination, DeliveryDestination, GoogleDriveAccount } from 
 const DEFAULT_FOLDER_TEMPLATE = '{YYYY}-{MM}-{DD}_{ClientName}_{Type}'
 const DEFAULT_FILE_TEMPLATE = '{original}'
 
-export function Settings() {
+interface SettingsProps {
+  isActive?: boolean
+}
+
+export function Settings({ isActive }: SettingsProps) {
   const { theme, setTheme } = useTheme()
   const { error: showError, success: showSuccess, warning: showWarning } = useNotification()
+  const isActiveRef = useRef(isActive ?? false)
+  useEffect(() => {
+    isActiveRef.current = isActive ?? false
+  }, [isActive])
   const [destinations, setDestinations] = useState<BackupDestination[]>([])
   const [newDestName, setNewDestName] = useState('')
   const [deliveryDestinations, setDeliveryDestinations] = useState<DeliveryDestination[]>([])
@@ -34,7 +42,7 @@ export function Settings() {
       setDriveAccount(account)
     } catch (error) {
       console.error('Failed to load Google Drive account:', error)
-      showError('Failed to load Google Drive account')
+      if (isActiveRef.current) showError('Failed to load Google Drive account')
     }
   }, [showError])
 
@@ -60,7 +68,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load destinations:', error)
-        showError('Failed to load destinations')
+        if (isActiveRef.current) showError('Failed to load destinations')
       }
     }
 
@@ -75,7 +83,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load delivery destinations:', error)
-        showError('Failed to load delivery destinations')
+        if (isActiveRef.current) showError('Failed to load delivery destinations')
       }
     }
 
@@ -87,7 +95,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load default import location:', error)
-        showError('Failed to load default import location')
+        if (isActiveRef.current) showError('Failed to load default import location')
       }
     }
 
@@ -99,7 +107,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load archive location:', error)
-        showError('Failed to load archive location')
+        if (isActiveRef.current) showError('Failed to load archive location')
       }
     }
 
@@ -115,7 +123,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load templates:', error)
-        showError('Failed to load template settings')
+        if (isActiveRef.current) showError('Failed to load template settings')
       }
     }
 
@@ -127,7 +135,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load auto-eject setting:', error)
-        showError('Failed to load auto-eject setting')
+        if (isActiveRef.current) showError('Failed to load auto-eject setting')
       }
     }
 
@@ -139,7 +147,7 @@ export function Settings() {
         }
       } catch (error) {
         console.error('Failed to load conflict mode:', error)
-        showError('Failed to load drive conflict mode')
+        if (isActiveRef.current) showError('Failed to load drive conflict mode')
       }
     }
 


### PR DESCRIPTION
## Motivation

`console.error`/`console.log` calls scattered across the frontend bypassed the
notification system, giving users no visible feedback and leaving noise in the
browser console. The codebase also had background-load toasts firing regardless
of which view was active, causing irrelevant popups.

## Implementation information

- Replaced `console.error` / `console.log` user-facing calls with
  `useNotification()` (`error`, `success`, `info`) throughout frontend
  components and hooks.
- Kept `console.error` only where it precedes a proper notification call (for
  developer-level logging) as per existing patterns in CLAUDE.md.
- Added an active-view guard so background-load toasts are only shown when the
  relevant view is currently mounted, eliminating spurious notifications.

Closes https://github.com/Automaat/creatorops/issues/154