### PR TITLE
fix(google-drive): distinguish TokenNotFound from other IO errors

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -26,7 +26,10 @@ pub enum AppError {
 
     /// Project not found
     #[error("Project not found: {id}")]
-    ProjectNotFound { id: String },
+    ProjectNotFound {
+        /// Project identifier
+        id: String,
+    },
 
     /// Backup operation cancelled
     #[error("Backup cancelled")]
@@ -66,6 +69,162 @@ impl From<AppError> for String {
     }
 }
 
+/// Errors from backup operations
+#[derive(Error, Debug)]
+pub enum BackupError {
+    /// File I/O error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Checksum mismatch after copy
+    #[error("Checksum verification failed")]
+    ChecksumMismatch,
+
+    /// Checksum calculation failure
+    #[error("Checksum failed: {0}")]
+    ChecksumFailed(String),
+
+    /// Source path has no file-name component
+    #[error("Invalid source path")]
+    InvalidPath,
+
+    /// Path prefix strip failed
+    #[error("Path error: {0}")]
+    PathError(String),
+
+    /// Recursive file collection failed
+    #[error("File collection failed: {0}")]
+    CollectFailed(String),
+
+    /// JSON serialization or deserialization error
+    #[error("Serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    /// Mutex lock acquisition failed
+    #[error("Failed to acquire lock: {0}")]
+    LockFailed(String),
+
+    /// Referenced backup job does not exist
+    #[error("Backup job not found")]
+    JobNotFound,
+
+    /// Tried to cancel a non-pending job
+    #[error("Can only cancel pending backups")]
+    NotPending,
+
+    /// Tried to remove an in-progress job
+    #[error("Cannot remove in-progress backup")]
+    InProgress,
+
+    /// Configuration or environment error
+    #[error("Configuration error: {0}")]
+    Config(String),
+}
+
+impl From<BackupError> for String {
+    fn from(err: BackupError) -> Self {
+        err.to_string()
+    }
+}
+
+/// Errors from delivery operations
+#[derive(Error, Debug)]
+pub enum DeliveryError {
+    /// File I/O error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// File has no valid name component
+    #[error("Invalid file name")]
+    InvalidFileName,
+
+    /// Path prefix strip failed
+    #[error("Path error: {0}")]
+    PathError(String),
+}
+
+impl From<DeliveryError> for String {
+    fn from(err: DeliveryError) -> Self {
+        err.to_string()
+    }
+}
+
+/// Errors from import (SD card copy) operations
+#[derive(Error, Debug)]
+pub enum ImportError {
+    /// Import was cancelled by the user
+    #[error("Import cancelled")]
+    Cancelled,
+
+    /// Tokio task join error
+    #[error("Task failed: {0}")]
+    TaskFailed(String),
+
+    /// Import token not found — session already completed
+    #[error("Import not found or already completed")]
+    NotFound,
+
+    /// Semaphore permit acquisition failed
+    #[error("Semaphore acquire failed: {0}")]
+    SemaphoreError(String),
+
+    /// Underlying file copy returned an error
+    #[error("File copy failed: {0}")]
+    CopyFailed(String),
+}
+
+impl From<ImportError> for String {
+    fn from(err: ImportError) -> Self {
+        err.to_string()
+    }
+}
+
+/// Errors from Google Drive authentication and API operations
+#[derive(Error, Debug)]
+pub enum GoogleDriveError {
+    /// File I/O error (token files, token directory)
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// HTTP/network failure
+    #[error("Network error: {0}")]
+    Network(String),
+
+    /// Non-2xx response from Google API
+    #[error("API error: {0}")]
+    ApiError(String),
+
+    /// Response parsing or deserialization failure
+    #[error("Invalid data: {0}")]
+    InvalidData(String),
+
+    /// AES-GCM encryption or decryption failure
+    #[error("Encryption error: {0}")]
+    Crypto(String),
+
+    /// Mutex lock acquisition failed
+    #[error("Failed to acquire lock")]
+    LockFailed,
+
+    /// No stored token found for the account
+    #[error("Token not found")]
+    TokenNotFound,
+
+    /// Configuration or environment variable missing
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// OAuth code exchange timed out
+    #[error("Authentication timeout")]
+    AuthTimeout,
+}
+
+impl From<GoogleDriveError> for String {
+    fn from(err: GoogleDriveError) -> Self {
+        err.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +256,95 @@ mod tests {
         let serde_err = serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
         let app_err: AppError = serde_err.into();
         assert!(app_err.to_string().contains("Serialization error"));
+    }
+
+    #[test]
+    fn test_backup_error_display() {
+        assert_eq!(
+            BackupError::ChecksumMismatch.to_string(),
+            "Checksum verification failed"
+        );
+        assert_eq!(BackupError::InvalidPath.to_string(), "Invalid source path");
+        assert_eq!(BackupError::JobNotFound.to_string(), "Backup job not found");
+        assert_eq!(
+            BackupError::NotPending.to_string(),
+            "Can only cancel pending backups"
+        );
+        assert_eq!(
+            BackupError::InProgress.to_string(),
+            "Cannot remove in-progress backup"
+        );
+    }
+
+    #[test]
+    fn test_backup_error_to_string_conversion() {
+        let s: String = BackupError::JobNotFound.into();
+        assert_eq!(s, "Backup job not found");
+    }
+
+    #[test]
+    fn test_backup_error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let err: BackupError = io_err.into();
+        assert!(err.to_string().contains("IO error"));
+    }
+
+    #[test]
+    fn test_delivery_error_display() {
+        assert_eq!(
+            DeliveryError::InvalidFileName.to_string(),
+            "Invalid file name"
+        );
+        assert_eq!(
+            DeliveryError::PathError("bad prefix".to_owned()).to_string(),
+            "Path error: bad prefix"
+        );
+    }
+
+    #[test]
+    fn test_delivery_error_to_string_conversion() {
+        let s: String = DeliveryError::InvalidFileName.into();
+        assert_eq!(s, "Invalid file name");
+    }
+
+    #[test]
+    fn test_import_error_display() {
+        assert_eq!(ImportError::Cancelled.to_string(), "Import cancelled");
+        assert_eq!(
+            ImportError::NotFound.to_string(),
+            "Import not found or already completed"
+        );
+    }
+
+    #[test]
+    fn test_import_error_to_string_conversion() {
+        let s: String = ImportError::Cancelled.into();
+        assert_eq!(s, "Import cancelled");
+    }
+
+    #[test]
+    fn test_google_drive_error_display() {
+        assert_eq!(
+            GoogleDriveError::LockFailed.to_string(),
+            "Failed to acquire lock"
+        );
+        assert_eq!(
+            GoogleDriveError::TokenNotFound.to_string(),
+            "Token not found"
+        );
+        assert_eq!(
+            GoogleDriveError::AuthTimeout.to_string(),
+            "Authentication timeout"
+        );
+        assert_eq!(
+            GoogleDriveError::ApiError("403 Forbidden".to_owned()).to_string(),
+            "API error: 403 Forbidden"
+        );
+    }
+
+    #[test]
+    fn test_google_drive_error_to_string_conversion() {
+        let s: String = GoogleDriveError::TokenNotFound.into();
+        assert_eq!(s, "Token not found");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the core library for the `CreatorOps` Tauri application.
 
-mod error;
+pub mod error;
 mod modules;
 mod progress;
 pub mod state;

--- a/src-tauri/src/modules/backup.rs
+++ b/src-tauri/src/modules/backup.rs
@@ -5,6 +5,7 @@
 //! completion record to `~/CreatorOps/backup_history.json`.
 
 #![allow(clippy::wildcard_imports)] // Tauri command macro uses wildcard imports
+use crate::error::BackupError;
 use crate::modules::file_utils::{
     collect_files_recursive, count_files_and_size, get_home_dir, get_timestamp, verify_checksum,
 };
@@ -241,7 +242,7 @@ pub async fn start_backup(
                 }
                 Err(e) => {
                     j.status = BackupStatus::Failed;
-                    j.error_message = Some(e);
+                    j.error_message = Some(e.to_string());
                     j.completed_at = Some(get_timestamp());
                 }
             }
@@ -358,19 +359,18 @@ async fn perform_backup(
     window: &tauri::Window,
     job_id: &str,
     job: &BackupJob,
-) -> Result<(usize, usize, u64), String> {
+) -> Result<(usize, usize, u64), BackupError> {
     let src_path = Path::new(&job.source_path);
     let dest_base = Path::new(&job.destination_path);
 
-    // Create destination with project folder name
     let project_folder_name = src_path
         .file_name()
-        .ok_or("Invalid source path")?
+        .ok_or(BackupError::InvalidPath)?
         .to_string_lossy();
     let dest_path = dest_base.join(project_folder_name.as_ref());
 
-    // Collect all files to copy
-    let files_to_copy = collect_files_recursive(src_path)?;
+    let files_to_copy =
+        collect_files_recursive(src_path).map_err(|e| BackupError::CollectFailed(e.to_string()))?;
 
     let total_files = files_to_copy.len();
     let start_time = std::time::Instant::now();
@@ -379,12 +379,13 @@ async fn perform_backup(
     let mut files_skipped = 0;
 
     for (index, src_file) in files_to_copy.iter().enumerate() {
-        let relative_path = src_file.strip_prefix(src_path).map_err(|e| e.to_string())?;
+        let relative_path = src_file
+            .strip_prefix(src_path)
+            .map_err(|e| BackupError::PathError(e.to_string()))?;
         let dest_file = dest_path.join(relative_path);
 
-        // Create parent directory
         if let Some(parent) = dest_file.parent() {
-            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            fs::create_dir_all(parent)?;
         }
 
         let file_name = src_file
@@ -446,64 +447,49 @@ async fn perform_backup(
     Ok((files_copied, files_skipped, bytes_transferred))
 }
 
-async fn copy_file_with_retry(src: &Path, dest: &Path) -> Result<u64, String> {
+async fn copy_file_with_retry(src: &Path, dest: &Path) -> Result<u64, BackupError> {
     let retry_strategy = ExponentialBackoff::from_millis(10)
         .map(jitter)
         .take(MAX_RETRY_ATTEMPTS);
 
     Retry::spawn(retry_strategy, || async {
-        // Copy file
         let size = copy_file(src, dest).await?;
 
-        // Verify checksum
         match verify_checksum(src, dest).await {
             Ok(true) => Ok(size),
             Ok(false) => {
-                // Checksum mismatch - retry
                 let _ = file_ops::remove_file(dest).await;
-                Err("Checksum verification failed".to_owned())
+                Err(BackupError::ChecksumMismatch)
             }
             Err(e) => {
                 let _ = file_ops::remove_file(dest).await;
-                Err(format!("Checksum calculation failed: {e}"))
+                Err(BackupError::ChecksumFailed(e.to_string()))
             }
         }
     })
     .await
 }
 
-async fn copy_file(src: &Path, dest: &Path) -> Result<u64, String> {
-    let mut src_file = tokio::fs::File::open(src)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let mut dest_file = tokio::fs::File::create(dest)
-        .await
-        .map_err(|e| e.to_string())?;
+async fn copy_file(src: &Path, dest: &Path) -> Result<u64, BackupError> {
+    let mut src_file = tokio::fs::File::open(src).await?;
+    let mut dest_file = tokio::fs::File::create(dest).await?;
 
     let mut buffer = vec![0_u8; CHUNK_SIZE];
     let mut total_bytes = 0_u64;
 
     loop {
-        let bytes_read = src_file
-            .read(&mut buffer)
-            .await
-            .map_err(|e| e.to_string())?;
+        let bytes_read = src_file.read(&mut buffer).await?;
 
         if bytes_read == 0 {
             break;
         }
 
-        dest_file
-            .write_all(&buffer[..bytes_read])
-            .await
-            .map_err(|e| e.to_string())?;
+        dest_file.write_all(&buffer[..bytes_read]).await?;
 
         total_bytes += bytes_read as u64;
     }
 
-    // Ensure all data is written to disk
-    dest_file.sync_all().await.map_err(|e| e.to_string())?;
+    dest_file.sync_all().await?;
 
     Ok(total_bytes)
 }
@@ -513,23 +499,19 @@ lazy_static::lazy_static! {
     static ref HISTORY_MUTEX: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
 }
 
-fn save_backup_to_history(job: &BackupJob) -> Result<(), String> {
-    // Acquire lock to prevent race conditions when multiple backups complete
+fn save_backup_to_history(job: &BackupJob) -> Result<(), BackupError> {
     let _lock = HISTORY_MUTEX
         .lock()
-        .map_err(|e| format!("Failed to lock history mutex: {e}"))?;
-    let home_dir = get_home_dir()?;
+        .map_err(|e| BackupError::LockFailed(e.to_string()))?;
+    let home_dir = get_home_dir().map_err(|e| BackupError::Config(e.to_string()))?;
     let history_dir = home_dir.join("CreatorOps");
-    fs::create_dir_all(&history_dir).map_err(|e| e.to_string())?;
+    fs::create_dir_all(&history_dir)?;
 
     let history_path = history_dir.join("backup_history.json");
 
     let mut history: Vec<BackupHistory> = if history_path.exists() {
-        let data = fs::read_to_string(&history_path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&data).map_err(|e| {
-            // Failed to deserialize - return empty history
-            e.to_string()
-        })?
+        let data = fs::read_to_string(&history_path)?;
+        serde_json::from_str(&data)?
     } else {
         Vec::new()
     };
@@ -551,13 +533,11 @@ fn save_backup_to_history(job: &BackupJob) -> Result<(), String> {
 
     history.push(entry);
 
-    let json_data = serde_json::to_string_pretty(&history).map_err(|e| e.to_string())?;
+    let json_data = serde_json::to_string_pretty(&history)?;
 
-    // Write and sync file to ensure data is persisted immediately
-    let mut file = fs::File::create(&history_path).map_err(|e| e.to_string())?;
-    file.write_all(json_data.as_bytes())
-        .map_err(|e| e.to_string())?;
-    file.sync_all().map_err(|e| e.to_string())?;
+    let mut file = fs::File::create(&history_path)?;
+    file.write_all(json_data.as_bytes())?;
+    file.sync_all()?;
 
     Ok(())
 }

--- a/src-tauri/src/modules/delivery.rs
+++ b/src-tauri/src/modules/delivery.rs
@@ -5,6 +5,7 @@
 //! the `delivery-progress` Tauri event.
 
 #![allow(clippy::wildcard_imports)] // Tauri command macro uses wildcard imports
+use crate::error::DeliveryError;
 use crate::modules::file_utils::{get_home_dir, get_timestamp};
 use crate::modules::project::Project;
 use serde::{Deserialize, Serialize};
@@ -115,27 +116,25 @@ fn collect_project_files(
     base_path: &Path,
     current_path: &Path,
     files: &mut Vec<ProjectFile>,
-) -> Result<(), String> {
-    for entry in fs::read_dir(current_path).map_err(|e| e.to_string())? {
-        let entry = entry.map_err(|e| e.to_string())?;
+) -> Result<(), DeliveryError> {
+    for entry in fs::read_dir(current_path)? {
+        let entry = entry?;
         let path = entry.path();
-        let metadata = entry.metadata().map_err(|e| e.to_string())?;
+        let metadata = entry.metadata()?;
 
         if metadata.is_dir() {
-            // Skip project.json metadata file directory
             if path.file_name().and_then(|n| n.to_str()) == Some("project.json") {
                 continue;
             }
             collect_project_files(base_path, &path, files)?;
         } else if metadata.is_file() {
-            // Skip project.json metadata file
             if path.file_name().and_then(|n| n.to_str()) == Some("project.json") {
                 continue;
             }
 
             let relative_path = path
                 .strip_prefix(base_path)
-                .map_err(|e| e.to_string())?
+                .map_err(|e| DeliveryError::PathError(e.to_string()))?
                 .to_string_lossy()
                 .to_string();
 
@@ -281,7 +280,7 @@ pub async fn start_delivery(
                 }
                 Err(e) => {
                     job.status = DeliveryStatus::Failed;
-                    job.error_message = Some(e);
+                    job.error_message = Some(e.to_string());
                     job.completed_at = Some(get_timestamp());
                 }
             }
@@ -296,10 +295,9 @@ async fn process_delivery(
     mut job: DeliveryJob,
     app_handle: tauri::AppHandle,
     delivery_queue: Arc<tokio::sync::Mutex<HashMap<String, DeliveryJob>>>,
-) -> Result<(), String> {
-    // Create delivery directory
+) -> Result<(), DeliveryError> {
     let delivery_path = Path::new(&job.delivery_path);
-    fs::create_dir_all(delivery_path).map_err(|e| e.to_string())?;
+    fs::create_dir_all(delivery_path)?;
 
     let start_time = std::time::Instant::now();
     let mut manifest_entries = Vec::new();
@@ -308,11 +306,10 @@ async fn process_delivery(
         let source_path = Path::new(source_file);
         let file_name = source_path
             .file_name()
-            .ok_or("Invalid file name")?
+            .ok_or(DeliveryError::InvalidFileName)?
             .to_string_lossy()
             .to_string();
 
-        // Apply naming template if provided
         let dest_name = job.naming_template.as_ref().map_or_else(
             || file_name.clone(),
             |template| apply_naming_template(template, &file_name, index),
@@ -320,7 +317,7 @@ async fn process_delivery(
 
         let dest_path = delivery_path.join(&dest_name);
 
-        let file_size = fs::metadata(source_path).map_err(|e| e.to_string())?.len();
+        let file_size = fs::metadata(source_path)?.len();
 
         copy_file_with_progress(
             source_path,
@@ -367,7 +364,7 @@ async fn process_delivery(
         manifest_entries.join("\n")
     );
 
-    fs::write(&manifest_path, manifest_content).map_err(|e| e.to_string())?;
+    fs::write(&manifest_path, manifest_content)?;
 
     // Update job with manifest path
     {
@@ -398,14 +395,9 @@ async fn copy_file_with_progress(
     total_bytes: u64,
     start_time: std::time::Instant,
     app_handle: &tauri::AppHandle,
-) -> Result<(), String> {
-    let mut source_file = tokio::fs::File::open(source)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let mut dest_file = tokio::fs::File::create(dest)
-        .await
-        .map_err(|e| e.to_string())?;
+) -> Result<(), DeliveryError> {
+    let mut source_file = tokio::fs::File::open(source).await?;
+    let mut dest_file = tokio::fs::File::create(dest).await?;
 
     let mut buffer = vec![0_u8; CHUNK_SIZE];
     let file_name = source
@@ -415,19 +407,13 @@ async fn copy_file_with_progress(
         .to_string();
 
     loop {
-        let bytes_read = source_file
-            .read(&mut buffer)
-            .await
-            .map_err(|e| e.to_string())?;
+        let bytes_read = source_file.read(&mut buffer).await?;
 
         if bytes_read == 0 {
             break;
         }
 
-        dest_file
-            .write_all(&buffer[..bytes_read])
-            .await
-            .map_err(|e| e.to_string())?;
+        dest_file.write_all(&buffer[..bytes_read]).await?;
 
         *bytes_transferred += bytes_read as u64;
 
@@ -469,7 +455,7 @@ async fn copy_file_with_progress(
         let _ = app_handle.emit("delivery-progress", &progress);
     }
 
-    dest_file.flush().await.map_err(|e| e.to_string())?;
+    dest_file.flush().await?;
 
     Ok(())
 }

--- a/src-tauri/src/modules/file_copy.rs
+++ b/src-tauri/src/modules/file_copy.rs
@@ -6,6 +6,7 @@
 //! exponential back-off; persistent failures are counted as skipped.
 
 #![allow(clippy::wildcard_imports)] // Tauri command macro uses wildcard imports
+use crate::error::ImportError;
 use crate::utils::file_ops;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -134,11 +135,13 @@ pub async fn copy_files(
         let app_clone = app.clone();
 
         let task = tokio::spawn(async move {
-            let _permit = semaphore_clone.acquire().await.map_err(|e| e.to_string())?;
+            let _permit = semaphore_clone
+                .acquire()
+                .await
+                .map_err(|e| ImportError::SemaphoreError(e.to_string()))?;
 
-            // Check if cancelled before starting work
             if cancel_token_clone.is_cancelled() {
-                return Err("Import cancelled".to_owned());
+                return Err(ImportError::Cancelled);
             }
 
             match copy_file_with_retry(&src, &dest_file, &cancel_token_clone).await {
@@ -148,7 +151,6 @@ pub async fn copy_files(
                     #[allow(clippy::cast_possible_truncation)]
                     total_bytes_clone.fetch_add(size as usize, Ordering::SeqCst);
 
-                    // Track photo/video counts
                     match file_type {
                         Some("photo") => {
                             photos_copied_clone.fetch_add(1, Ordering::SeqCst);
@@ -159,7 +161,6 @@ pub async fn copy_files(
                         _ => {}
                     }
 
-                    // Emit progress event
                     let _ = app_clone.emit(
                         "import-progress",
                         ImportProgress {
@@ -171,11 +172,8 @@ pub async fn copy_files(
 
                     Ok(())
                 }
+                Err(ImportError::Cancelled) => Err(ImportError::Cancelled),
                 Err(e) => {
-                    if cancel_token_clone.is_cancelled() {
-                        return Err("Import cancelled".to_owned());
-                    }
-                    // Copy failed after retries - track as skipped
                     files_skipped_clone.fetch_add(1, Ordering::SeqCst);
                     skipped_files_clone.lock().await.push(file_name);
                     Err(e)
@@ -186,16 +184,13 @@ pub async fn copy_files(
         tasks.push(task);
     }
 
-    // Wait for all tasks and handle errors
     let mut cancelled = false;
     for result in futures::future::join_all(tasks).await {
-        #[allow(clippy::match_same_arms)] // Different semantics: success vs failure
         match result {
-            Ok(Ok(())) => {} // Success
-            Ok(Err(e)) if e == "Import cancelled" => {
+            Ok(Err(ImportError::Cancelled)) => {
                 cancelled = true;
             }
-            Ok(Err(_)) => {} // File copy failed, already counted as skipped
+            Ok(Ok(()) | Err(_)) => {}
             Err(e) => return Err(format!("Task failed: {e}")),
         }
     }
@@ -236,17 +231,18 @@ async fn copy_file_with_retry(
     src: &Path,
     dest: &Path,
     cancel_token: &CancellationToken,
-) -> Result<u64, String> {
+) -> Result<u64, ImportError> {
     let retry_strategy = ExponentialBackoff::from_millis(10)
         .map(jitter)
         .take(MAX_RETRY_ATTEMPTS);
 
     Retry::spawn(retry_strategy, || async {
         if cancel_token.is_cancelled() {
-            return Err("Import cancelled".to_owned());
+            return Err(ImportError::Cancelled);
         }
-        // Use spawn_blocking for efficient sync file copy (Phase 3 optimization)
-        file_ops::copy_file(src, dest).await
+        file_ops::copy_file(src, dest)
+            .await
+            .map_err(ImportError::CopyFailed)
     })
     .await
 }
@@ -259,10 +255,10 @@ async fn copy_file_with_retry(
 pub async fn cancel_import_impl(
     import_tokens: &crate::state::ImportTokens,
     import_id: String,
-) -> Result<(), String> {
+) -> Result<(), ImportError> {
     let tokens = import_tokens.lock().await;
     tokens.get(&import_id).map_or_else(
-        || Err("Import not found or already completed".to_owned()),
+        || Err(ImportError::NotFound),
         |token| {
             token.cancel();
             Ok(())
@@ -276,7 +272,9 @@ pub async fn cancel_import(
     state: tauri::State<'_, crate::state::AppState>,
     import_id: String,
 ) -> Result<(), String> {
-    cancel_import_impl(&state.import_tokens, import_id).await
+    cancel_import_impl(&state.import_tokens, import_id)
+        .await
+        .map_err(String::from)
 }
 
 #[allow(clippy::wildcard_imports)]
@@ -394,7 +392,7 @@ mod tests {
         let result = copy_file_with_retry(&src, &dest, &cancel_token).await;
 
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Import cancelled");
+        assert!(matches!(result.unwrap_err(), ImportError::Cancelled));
     }
 
     #[tokio::test]
@@ -744,7 +742,7 @@ mod tests {
         let result = copy_file_with_retry(&src, &dest, &cancel_token).await;
 
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Import cancelled");
+        assert!(matches!(result.unwrap_err(), ImportError::Cancelled));
     }
 
     #[tokio::test]

--- a/src-tauri/src/modules/google_drive.rs
+++ b/src-tauri/src/modules/google_drive.rs
@@ -9,6 +9,7 @@
 
 #![allow(clippy::unreachable)] // False positive: Clippy incorrectly flags Result returns
 
+use crate::error::GoogleDriveError;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::{DateTime, Utc};
 use http_body_util::Full;
@@ -222,12 +223,12 @@ async fn exchange_code_for_tokens(
     client_secret: &str,
     redirect_uri: &str,
     code_verifier: &str,
-) -> Result<TokenResponse, String> {
+) -> Result<TokenResponse, GoogleDriveError> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECONDS))
         .connect_timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| GoogleDriveError::Network(format!("Failed to create HTTP client: {e}")))?;
 
     let params = [
         ("code", code),
@@ -243,31 +244,32 @@ async fn exchange_code_for_tokens(
         .form(&params)
         .send()
         .await
-        .map_err(|e| format!("Token exchange request failed: {e}"))?;
+        .map_err(|e| GoogleDriveError::Network(format!("Token exchange request failed: {e}")))?;
 
     if !response.status().is_success() {
         let error_text = response
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_owned());
-        return Err(format!("Token exchange failed: {error_text}"));
+        return Err(GoogleDriveError::ApiError(format!(
+            "Token exchange failed: {error_text}"
+        )));
     }
 
     response
         .json::<TokenResponse>()
         .await
-        .map_err(|e| format!("Failed to parse token response: {e}"))
+        .map_err(|e| GoogleDriveError::InvalidData(format!("Failed to parse token response: {e}")))
 }
 
-async fn get_user_info(access_token: &str) -> Result<UserInfo, String> {
+async fn get_user_info(access_token: &str) -> Result<UserInfo, GoogleDriveError> {
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECONDS)) // Increase timeout
-        .connect_timeout(std::time::Duration::from_secs(30)) // Add connection timeout
+        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECONDS))
+        .connect_timeout(std::time::Duration::from_secs(30))
         .pool_idle_timeout(std::time::Duration::from_secs(90))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| GoogleDriveError::Network(format!("Failed to create HTTP client: {e}")))?;
 
-    // Retry logic with exponential backoff for network failures (3 total attempts)
     let mut retries = 2;
     let mut delay = std::time::Duration::from_secs(1);
 
@@ -289,10 +291,12 @@ async fn get_user_info(access_token: &str) -> Result<UserInfo, String> {
                 log::warn!("User info request failed: {e}, retrying in {delay:?}");
                 tokio::time::sleep(delay).await;
                 retries -= 1;
-                delay *= 2; // Exponential backoff
+                delay *= 2;
             }
             Err(e) => {
-                return Err(format!("User info request failed after retries: {e}"));
+                return Err(GoogleDriveError::Network(format!(
+                    "User info request failed after retries: {e}"
+                )));
             }
         }
     };
@@ -302,13 +306,15 @@ async fn get_user_info(access_token: &str) -> Result<UserInfo, String> {
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_owned());
-        return Err(format!("User info request failed: {error_text}"));
+        return Err(GoogleDriveError::ApiError(format!(
+            "User info request failed: {error_text}"
+        )));
     }
 
     response
         .json::<UserInfo>()
         .await
-        .map_err(|e| format!("Failed to parse user info: {e}"))
+        .map_err(|e| GoogleDriveError::InvalidData(format!("Failed to parse user info: {e}")))
 }
 
 // OAuth Tauri Commands
@@ -647,20 +653,19 @@ pub async fn test_google_drive_connection(db: tauri::State<'_, Database>) -> Res
         account.id
     );
 
-    // Get valid access token (handles refresh if needed)
     let access_token = get_valid_access_token(&account.email).await.map_err(|e| {
         log::error!("Failed to get valid access token for {}: {}", account.email, e);
-
-        if e.contains("Failed to read token file") || e.contains("No such file") || e.contains("Failed to get tokens") {
-            format!("Authentication expired - please disconnect and reconnect your account. (Error: {e})")
-        } else if e.contains("Failed to deserialize") || e.contains("Failed to decrypt") {
-            format!("Token data corrupted - please disconnect and reconnect your account. (Error: {e})")
-        } else {
-            e
+        match &e {
+            GoogleDriveError::Io(_) | GoogleDriveError::TokenNotFound => {
+                format!("Authentication expired - please disconnect and reconnect your account. (Error: {e})")
+            }
+            GoogleDriveError::InvalidData(_) | GoogleDriveError::Crypto(_) => {
+                format!("Token data corrupted - please disconnect and reconnect your account. (Error: {e})")
+            }
+            _ => e.to_string(),
         }
     })?;
 
-    // Test connection by fetching user info
     log::info!("Testing connection by fetching user info...");
     get_user_info(&access_token).await.map_err(|e| {
         log::error!("Failed to get user info: {e}");
@@ -674,8 +679,9 @@ pub async fn test_google_drive_connection(db: tauri::State<'_, Database>) -> Res
 // Token Management Functions
 
 /// Get the token file path for a given email address
-fn get_token_file_path(email: &str) -> Result<String, String> {
-    let home = std::env::var("HOME").map_err(|_| "Failed to get HOME directory")?;
+fn get_token_file_path(email: &str) -> Result<String, GoogleDriveError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| GoogleDriveError::Config("HOME directory not set".to_owned()))?;
     let normalized_email = email.to_lowercase();
     Ok(format!(
         "{}/.creatorops/google_tokens_{}.enc",
@@ -686,7 +692,7 @@ fn get_token_file_path(email: &str) -> Result<String, String> {
 
 /// Generate a machine-specific encryption key
 #[allow(clippy::unnecessary_wraps)]
-fn get_encryption_key() -> Result<[u8; 32], String> {
+fn get_encryption_key() -> Result<[u8; 32], GoogleDriveError> {
     use sha2::{Digest, Sha256};
 
     // Combine multiple machine-specific values for the key
@@ -718,21 +724,20 @@ fn get_encryption_key() -> Result<[u8; 32], String> {
 
 /// Encrypt data using AES-256-GCM for secure token storage
 /// Uses authenticated encryption with random nonces for each encryption
-fn encrypt_data(data: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+fn encrypt_data(data: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, GoogleDriveError> {
     use aes_gcm::{
         aead::{Aead, AeadCore, KeyInit, OsRng},
         Aes256Gcm,
     };
 
-    let cipher =
-        Aes256Gcm::new_from_slice(key).map_err(|e| format!("Failed to create cipher: {e}"))?;
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| GoogleDriveError::Crypto(format!("Failed to create cipher: {e}")))?;
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
 
     let ciphertext = cipher
         .encrypt(&nonce, data)
-        .map_err(|e| format!("Failed to encrypt data: {e}"))?;
+        .map_err(|e| GoogleDriveError::Crypto(format!("Failed to encrypt data: {e}")))?;
 
-    // Prepend nonce to ciphertext for storage
     let mut result = nonce.to_vec();
     result.extend_from_slice(&ciphertext);
 
@@ -741,73 +746,66 @@ fn encrypt_data(data: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
 
 /// Decrypt data using AES-256-GCM authenticated encryption
 /// Validates authenticity and integrity before returning plaintext
-fn decrypt_data(encrypted: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+fn decrypt_data(encrypted: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, GoogleDriveError> {
     use aes_gcm::{
         aead::{Aead, KeyInit},
         Aes256Gcm, Nonce,
     };
 
-    // Extract nonce (first 12 bytes) and ciphertext
     if encrypted.len() < 12 {
-        return Err("Invalid encrypted data: too short".to_owned());
+        return Err(GoogleDriveError::Crypto(
+            "Invalid encrypted data: too short".to_owned(),
+        ));
     }
 
     let (nonce_bytes, ciphertext) = encrypted.split_at(12);
     let nonce = Nonce::from_slice(nonce_bytes);
 
-    let cipher =
-        Aes256Gcm::new_from_slice(key).map_err(|e| format!("Failed to create cipher: {e}"))?;
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| GoogleDriveError::Crypto(format!("Failed to create cipher: {e}")))?;
 
     cipher
         .decrypt(nonce, ciphertext)
-        .map_err(|e| format!("Failed to decrypt data: {e}"))
+        .map_err(|e| GoogleDriveError::Crypto(format!("Failed to decrypt data: {e}")))
 }
 
 /// Persist OAuth tokens to an encrypted file in `~/.creatorops/tokens/`.
-fn store_tokens_in_keychain(email: &str, tokens: &TokenData) -> Result<(), String> {
+fn store_tokens_in_keychain(email: &str, tokens: &TokenData) -> Result<(), GoogleDriveError> {
     use base64::{engine::general_purpose, Engine as _};
 
     log::info!("Storing tokens for email: '{email}'");
 
-    // Use encrypted file-based approach as fallback for keychain issues
-    let home = std::env::var("HOME").map_err(|_| "Failed to get HOME directory")?;
+    let home = std::env::var("HOME")
+        .map_err(|_| GoogleDriveError::Config("HOME directory not set".to_owned()))?;
     let token_dir = format!("{home}/.creatorops");
-    std::fs::create_dir_all(&token_dir)
-        .map_err(|e| format!("Failed to create token directory: {e}"))?;
+    std::fs::create_dir_all(&token_dir)?;
 
-    // Set restrictive permissions on the directory (owner only)
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let metadata =
-            std::fs::metadata(&token_dir).map_err(|e| format!("Failed to get metadata: {e}"))?;
+        let metadata = std::fs::metadata(&token_dir)?;
         let mut permissions = metadata.permissions();
         permissions.set_mode(0o700);
-        std::fs::set_permissions(&token_dir, permissions)
-            .map_err(|e| format!("Failed to set permissions: {e}"))?;
+        std::fs::set_permissions(&token_dir, permissions)?;
     }
 
     let token_file = get_token_file_path(email)?;
-    let token_json =
-        serde_json::to_string(&tokens).map_err(|e| format!("Failed to serialize tokens: {e}"))?;
+    let token_json = serde_json::to_string(&tokens)
+        .map_err(|e| GoogleDriveError::InvalidData(format!("Failed to serialize tokens: {e}")))?;
 
-    // Encrypt the token data
     let key = get_encryption_key()?;
     let encrypted = encrypt_data(token_json.as_bytes(), &key)?;
     let encoded = general_purpose::STANDARD.encode(&encrypted);
 
-    std::fs::write(&token_file, encoded).map_err(|e| format!("Failed to write token file: {e}"))?;
+    std::fs::write(&token_file, encoded)?;
 
-    // Set restrictive permissions on the file (owner read/write only)
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let metadata =
-            std::fs::metadata(&token_file).map_err(|e| format!("Failed to get metadata: {e}"))?;
+        let metadata = std::fs::metadata(&token_file)?;
         let mut permissions = metadata.permissions();
         permissions.set_mode(0o600);
-        std::fs::set_permissions(&token_file, permissions)
-            .map_err(|e| format!("Failed to set permissions: {e}"))?;
+        std::fs::set_permissions(&token_file, permissions)?;
     }
 
     log::info!("Successfully stored encrypted tokens for email: '{email}'");
@@ -815,30 +813,29 @@ fn store_tokens_in_keychain(email: &str, tokens: &TokenData) -> Result<(), Strin
 }
 
 /// Load OAuth tokens from the encrypted file written by `store_tokens_in_keychain`.
-fn get_tokens_from_keychain(email: &str) -> Result<TokenData, String> {
+fn get_tokens_from_keychain(email: &str) -> Result<TokenData, GoogleDriveError> {
     use base64::{engine::general_purpose, Engine as _};
 
     log::info!("Attempting to get tokens for email: '{email}'");
 
-    // Use encrypted file-based approach as fallback for keychain issues
     let token_file = get_token_file_path(email)?;
 
     let encoded = std::fs::read_to_string(&token_file).map_err(|e| {
         log::error!("Failed to read token file for '{email}': {e}");
-        format!("Failed to get tokens: {e}")
+        GoogleDriveError::Io(e)
     })?;
 
-    // Decrypt the token data
     let encrypted = general_purpose::STANDARD
         .decode(&encoded)
-        .map_err(|e| format!("Failed to decode token data: {e}"))?;
+        .map_err(|e| GoogleDriveError::InvalidData(format!("Failed to decode token data: {e}")))?;
     let key = get_encryption_key()?;
     let decrypted = decrypt_data(&encrypted, &key)?;
-    let token_json = String::from_utf8(decrypted)
-        .map_err(|e| format!("Failed to decode decrypted data: {e}"))?;
+    let token_json = String::from_utf8(decrypted).map_err(|e| {
+        GoogleDriveError::InvalidData(format!("Failed to decode decrypted data: {e}"))
+    })?;
 
     let tokens: TokenData = serde_json::from_str(&token_json)
-        .map_err(|e| format!("Failed to deserialize tokens: {e}"))?;
+        .map_err(|e| GoogleDriveError::InvalidData(format!("Failed to deserialize tokens: {e}")))?;
 
     log::info!("Successfully retrieved and decrypted tokens for email: '{email}'");
     Ok(tokens)
@@ -851,7 +848,7 @@ struct RefreshResponse {
 }
 
 /// Exchange a refresh token for a new access token via the Google OAuth endpoint.
-async fn refresh_access_token(refresh_token: &str) -> Result<TokenData, String> {
+async fn refresh_access_token(refresh_token: &str) -> Result<TokenData, GoogleDriveError> {
     let client_id = std::env::var("GOOGLE_CLIENT_ID")
         .unwrap_or_else(|_| "YOUR_CLIENT_ID.apps.googleusercontent.com".to_owned());
     let client_secret =
@@ -861,7 +858,7 @@ async fn refresh_access_token(refresh_token: &str) -> Result<TokenData, String> 
         .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECONDS))
         .connect_timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| GoogleDriveError::Network(format!("Failed to create HTTP client: {e}")))?;
 
     let params = [
         ("client_id", client_id.as_str()),
@@ -875,20 +872,21 @@ async fn refresh_access_token(refresh_token: &str) -> Result<TokenData, String> 
         .form(&params)
         .send()
         .await
-        .map_err(|e| format!("Token refresh request failed: {e}"))?;
+        .map_err(|e| GoogleDriveError::Network(format!("Token refresh request failed: {e}")))?;
 
     if !response.status().is_success() {
         let error_text = response
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_owned());
-        return Err(format!("Token refresh failed: {error_text}"));
+        return Err(GoogleDriveError::ApiError(format!(
+            "Token refresh failed: {error_text}"
+        )));
     }
 
-    let refresh_response = response
-        .json::<RefreshResponse>()
-        .await
-        .map_err(|e| format!("Failed to parse refresh response: {e}"))?;
+    let refresh_response = response.json::<RefreshResponse>().await.map_err(|e| {
+        GoogleDriveError::InvalidData(format!("Failed to parse refresh response: {e}"))
+    })?;
 
     Ok(TokenData {
         access_token: refresh_response.access_token,
@@ -933,8 +931,7 @@ fn get_current_timestamp() -> String {
 }
 
 /// Get valid access token, refreshing if needed
-async fn get_valid_access_token(email: &str) -> Result<String, String> {
-    // Normalize email for consistent keychain access
+async fn get_valid_access_token(email: &str) -> Result<String, GoogleDriveError> {
     let normalized_email = email.to_lowercase();
 
     let mut tokens = get_tokens_from_keychain(&normalized_email).map_err(|e| {
@@ -942,13 +939,11 @@ async fn get_valid_access_token(email: &str) -> Result<String, String> {
         e
     })?;
 
-    // Check if token is expired or will expire in next 5 minutes
     let now = Utc::now();
     let buffer = chrono::Duration::minutes(5);
 
     if tokens.expires_at - buffer < now {
         log::info!("Token expired or expiring soon for {normalized_email}, refreshing");
-        // Token expired or expiring soon, refresh it
         tokens = refresh_access_token(&tokens.refresh_token).await?;
         store_tokens_in_keychain(&normalized_email, &tokens)?;
     }
@@ -1875,7 +1870,7 @@ mod tests {
         let nonexistent_email = format!("nonexistent-{}@example.com", Uuid::new_v4());
         let result = get_tokens_from_keychain(&nonexistent_email);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Failed to get tokens"));
+        assert!(matches!(result.unwrap_err(), GoogleDriveError::Io(_)));
     }
 
     #[test]
@@ -2191,7 +2186,7 @@ mod tests {
         let short_data = vec![1, 2, 3];
         let result = decrypt_data(&short_data, &key);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("too short"));
+        assert!(result.unwrap_err().to_string().contains("too short"));
 
         // Invalid ciphertext (random data)
         let mut invalid_data = vec![0_u8; 50];
@@ -2526,7 +2521,10 @@ mod tests {
 
         let result = get_tokens_from_keychain(&email);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Failed to decode token data"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to decode token data"));
 
         // Clean up
         let _ = std::fs::remove_file(token_file);

--- a/src-tauri/src/modules/google_drive.rs
+++ b/src-tauri/src/modules/google_drive.rs
@@ -656,7 +656,7 @@ pub async fn test_google_drive_connection(db: tauri::State<'_, Database>) -> Res
     let access_token = get_valid_access_token(&account.email).await.map_err(|e| {
         log::error!("Failed to get valid access token for {}: {}", account.email, e);
         match &e {
-            GoogleDriveError::Io(_) | GoogleDriveError::TokenNotFound => {
+            GoogleDriveError::TokenNotFound => {
                 format!("Authentication expired - please disconnect and reconnect your account. (Error: {e})")
             }
             GoogleDriveError::InvalidData(_) | GoogleDriveError::Crypto(_) => {
@@ -822,7 +822,11 @@ fn get_tokens_from_keychain(email: &str) -> Result<TokenData, GoogleDriveError> 
 
     let encoded = std::fs::read_to_string(&token_file).map_err(|e| {
         log::error!("Failed to read token file for '{email}': {e}");
-        GoogleDriveError::Io(e)
+        if e.kind() == std::io::ErrorKind::NotFound {
+            GoogleDriveError::TokenNotFound
+        } else {
+            GoogleDriveError::Io(e)
+        }
     })?;
 
     let encrypted = general_purpose::STANDARD

--- a/src-tauri/tests/integration_state.rs
+++ b/src-tauri/tests/integration_state.rs
@@ -4,8 +4,9 @@
 
 use creatorops_lib::{
     cancel_backup_impl, cancel_import_impl, create_archive_impl, create_delivery_impl,
-    get_archive_queue_impl, get_backup_queue_impl, get_delivery_queue_impl, queue_backup_impl,
-    remove_archive_job_impl, remove_backup_job_impl, remove_delivery_job_impl, state::AppState,
+    error::ImportError, get_archive_queue_impl, get_backup_queue_impl, get_delivery_queue_impl,
+    queue_backup_impl, remove_archive_job_impl, remove_backup_job_impl, remove_delivery_job_impl,
+    state::AppState,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -304,7 +305,7 @@ mod file_copy_integration_tests {
 
         let result = cancel_import_impl(&state.import_tokens, "nonexistent-id".to_owned()).await;
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Import not found or already completed");
+        assert!(matches!(result.unwrap_err(), ImportError::NotFound));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

`get_tokens_from_keychain` was returning the same `Io` error variant for
all filesystem failures — including missing-token (expected) and permission
errors or disk failures (unexpected). This caused callers like
`test_google_drive_connection` to treat any I/O problem as an
authentication expiry, producing misleading error messages in the UI.

## Implementation information

Built on the custom `AppError` type introduced in the backend refactor:

- `get_tokens_from_keychain`: maps `ErrorKind::NotFound` → `AppError::TokenNotFound`
  and keeps all other filesystem failures under `AppError::Io`
- `test_google_drive_connection`: now matches only `TokenNotFound` for the
  "authentication expired" message path; other `Io` errors surface as-is

No changes to the frontend or public Tauri command signatures.

Closes https://github.com/Automaat/creatorops/issues/160