### PR TITLE
feat(clients): add client management system

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ use modules::backup::{
 };
 use modules::client::{
     create_client, delete_client, get_client, list_clients, migrate_clients_from_projects,
-    search_clients, update_client, update_client_status,
+    run_client_migration, search_clients, update_client, update_client_status,
 };
 use modules::delivery::{
     create_delivery, get_delivery_queue, list_project_files, remove_delivery_job, start_delivery,
@@ -73,6 +73,12 @@ pub fn run() -> AppResult {
     // Initialize database with dependency injection
     let db =
         modules::db::Database::new().map_err(|e| format!("Failed to initialize database: {e}"))?;
+
+    // Link any unlinked projects to client records — idempotent, runs on every startup
+    // so restored databases and new legacy rows are always covered.
+    if let Err(e) = run_client_migration(&db) {
+        log::warn!("Client migration failed: {e}");
+    }
 
     // Initialize application state
     let app_state = state::AppState::default();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,10 @@ use modules::backup::{
     cancel_backup, get_backup_history, get_backup_queue, get_project_backup_history, queue_backup,
     remove_backup_job, start_backup,
 };
+use modules::client::{
+    create_client, delete_client, get_client, list_clients, migrate_clients_from_projects,
+    search_clients, update_client, update_client_status,
+};
 use modules::delivery::{
     create_delivery, get_delivery_queue, list_project_files, remove_delivery_job, start_delivery,
 };
@@ -85,6 +89,14 @@ pub fn run() -> AppResult {
             eject_sd_card,
             copy_files,
             cancel_import,
+            create_client,
+            list_clients,
+            get_client,
+            update_client,
+            update_client_status,
+            delete_client,
+            search_clients,
+            migrate_clients_from_projects,
             create_project,
             list_projects,
             get_project,

--- a/src-tauri/src/modules/client.rs
+++ b/src-tauri/src/modules/client.rs
@@ -401,11 +401,9 @@ pub async fn search_clients(
     .map_err(|e| format!("Database error: {e}"))
 }
 
-/// One-time migration: extract unique client names from projects and create client records.
-/// Updates `projects.client_id` to reference the newly created clients.
+/// Link unlinked projects to client records by matching `client_name`.
 /// Safe to call multiple times — skips projects that already have `client_id` set.
-#[tauri::command]
-pub async fn migrate_clients_from_projects(db: tauri::State<'_, Database>) -> Result<(), String> {
+pub fn run_client_migration(db: &Database) -> Result<(), AppError> {
     let now = chrono::Utc::now().to_rfc3339();
 
     db.execute(|conn| {
@@ -447,9 +445,12 @@ pub async fn migrate_clients_from_projects(db: tauri::State<'_, Database>) -> Re
 
         Ok(())
     })
-    .map_err(|e| format!("Migration failed: {e}"))?;
+}
 
-    Ok(())
+/// Tauri command wrapper — delegates to `run_client_migration`.
+#[tauri::command]
+pub async fn migrate_clients_from_projects(db: tauri::State<'_, Database>) -> Result<(), String> {
+    run_client_migration(&db).map_err(|e| format!("Migration failed: {e}"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/client.rs
+++ b/src-tauri/src/modules/client.rs
@@ -1,0 +1,775 @@
+//! Client management module — CRUD for photography clients.
+//!
+//! Each client can own multiple projects. The `client_name` field in projects
+//! is denormalized (kept in sync) to avoid JOINs in `list_projects` hot path.
+
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::AppError;
+use crate::modules::db::Database;
+use crate::modules::project::{map_project_row, Project};
+
+/// Client status — active or soft-deleted via archival.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ClientStatus {
+    Active,
+    Archived,
+}
+
+impl std::fmt::Display for ClientStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::Archived => write!(f, "archived"),
+        }
+    }
+}
+
+impl std::str::FromStr for ClientStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "archived" => Ok(Self::Archived),
+            _ => Err(format!("Invalid client status: {s}")),
+        }
+    }
+}
+
+/// Core client entity stored in `SQLite` and serialised to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Client {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    pub status: ClientStatus,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Client with its associated projects (for detail view).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientWithProjects {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    pub status: ClientStatus,
+    pub created_at: String,
+    pub updated_at: String,
+    pub projects: Vec<Project>,
+}
+
+/// Validate email — checks for exactly one @, non-empty local/domain parts,
+/// and at least one dot in the domain that isn't at the start or end.
+fn validate_email(email: &str) -> bool {
+    let at_idx = match email.find('@') {
+        Some(i) if !email[i + 1..].contains('@') => i,
+        _ => return false,
+    };
+    let local = &email[..at_idx];
+    let domain = &email[at_idx + 1..];
+    if local.is_empty() || local.contains(' ') {
+        return false;
+    }
+    if domain.is_empty() || domain.contains(' ') {
+        return false;
+    }
+    matches!(domain.rfind('.'), Some(dot) if dot > 0 && dot < domain.len() - 1)
+}
+
+/// Map a database row to a Client struct.
+fn map_client_row(row: &rusqlite::Row) -> rusqlite::Result<Client> {
+    let status_str: String = row.get(5)?;
+    let status = status_str.parse::<ClientStatus>().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            5,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    Ok(Client {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        email: row.get(2)?,
+        phone: row.get(3)?,
+        notes: row.get(4)?,
+        status,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+/// Fetch a single client by ID.
+pub fn get_client_by_id(db: &Database, client_id: &str) -> Result<Client, AppError> {
+    db.execute(|conn| {
+        let mut stmt = conn.prepare(
+            "SELECT id, name, email, phone, notes, status, created_at, updated_at
+             FROM clients WHERE id = ?1",
+        )?;
+        stmt.query_row(params![client_id], map_client_row)
+            .map_err(|e| {
+                if e == rusqlite::Error::QueryReturnedNoRows {
+                    AppError::InvalidData(format!("Client not found: {client_id}"))
+                } else {
+                    AppError::from(e)
+                }
+            })
+    })
+}
+
+/// Create a new client.
+#[tauri::command]
+pub async fn create_client(
+    db: tauri::State<'_, Database>,
+    name: String,
+    email: Option<String>,
+    phone: Option<String>,
+    notes: Option<String>,
+) -> Result<Client, String> {
+    let name = name.trim().to_owned();
+    if name.is_empty() {
+        return Err("Client name is required".to_owned());
+    }
+
+    if let Some(ref e) = email {
+        if !e.is_empty() && !validate_email(e) {
+            return Err("Invalid email format".to_owned());
+        }
+    }
+
+    let id = Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    let email = email.filter(|e| !e.is_empty());
+    let phone = phone.filter(|p| !p.is_empty());
+    let notes = notes.filter(|n| !n.is_empty());
+
+    let client = Client {
+        id,
+        name,
+        email,
+        phone,
+        notes,
+        status: ClientStatus::Active,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+
+    db.execute(|conn| {
+        conn.execute(
+            "INSERT INTO clients (id, name, email, phone, notes, status, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                &client.id,
+                &client.name,
+                &client.email,
+                &client.phone,
+                &client.notes,
+                client.status.to_string(),
+                &client.created_at,
+                &client.updated_at,
+            ],
+        )?;
+        Ok(())
+    })
+    .map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("UNIQUE constraint failed") {
+            format!("A client named '{}' already exists", client.name)
+        } else {
+            format!("Failed to create client: {msg}")
+        }
+    })?;
+
+    Ok(client)
+}
+
+/// List all clients, optionally including archived ones.
+#[tauri::command]
+pub async fn list_clients(
+    db: tauri::State<'_, Database>,
+    include_archived: Option<bool>,
+) -> Result<Vec<Client>, String> {
+    let include_archived = include_archived.unwrap_or(false);
+
+    db.execute(|conn| {
+        let sql = if include_archived {
+            "SELECT id, name, email, phone, notes, status, created_at, updated_at
+             FROM clients ORDER BY name ASC"
+        } else {
+            "SELECT id, name, email, phone, notes, status, created_at, updated_at
+             FROM clients WHERE status = 'active' ORDER BY name ASC"
+        };
+
+        let mut stmt = conn.prepare(sql)?;
+        let clients = stmt
+            .query_map([], map_client_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(clients)
+    })
+    .map_err(|e| format!("Database error: {e}"))
+}
+
+/// Get a single client with all its projects.
+#[tauri::command]
+pub async fn get_client(
+    db: tauri::State<'_, Database>,
+    client_id: String,
+) -> Result<ClientWithProjects, String> {
+    let client = get_client_by_id(&db, &client_id).map_err(String::from)?;
+
+    let projects = db
+        .execute(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, name, client_name, date, shoot_type, status, folder_path,
+                        created_at, updated_at, deadline, client_id
+                 FROM projects WHERE client_id = ?1 ORDER BY updated_at DESC",
+            )?;
+            let rows = stmt
+                .query_map(params![client_id], map_project_row)?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })
+        .map_err(|e| format!("Failed to load client projects: {e}"))?;
+
+    Ok(ClientWithProjects {
+        id: client.id,
+        name: client.name,
+        email: client.email,
+        phone: client.phone,
+        notes: client.notes,
+        status: client.status,
+        created_at: client.created_at,
+        updated_at: client.updated_at,
+        projects,
+    })
+}
+
+/// Update client metadata. When name changes, syncs denormalized `client_name` in projects.
+#[tauri::command]
+pub async fn update_client(
+    db: tauri::State<'_, Database>,
+    client_id: String,
+    name: Option<String>,
+    email: Option<String>,
+    phone: Option<String>,
+    notes: Option<String>,
+) -> Result<Client, String> {
+    let existing = get_client_by_id(&db, &client_id).map_err(String::from)?;
+
+    let new_name = name
+        .map(|n| n.trim().to_owned())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| existing.name.clone());
+
+    if let Some(ref e) = email {
+        if !e.is_empty() && !validate_email(e) {
+            return Err("Invalid email format".to_owned());
+        }
+    }
+
+    let new_email = email
+        .map(|e| if e.is_empty() { None } else { Some(e) })
+        .unwrap_or(existing.email);
+    let new_phone = phone
+        .map(|p| if p.is_empty() { None } else { Some(p) })
+        .unwrap_or(existing.phone);
+    let new_notes = notes
+        .map(|n| if n.is_empty() { None } else { Some(n) })
+        .unwrap_or(existing.notes);
+    let now = chrono::Utc::now().to_rfc3339();
+    let name_changed = new_name != existing.name;
+
+    db.execute(|conn| {
+        conn.execute(
+            "UPDATE clients SET name = ?1, email = ?2, phone = ?3, notes = ?4, updated_at = ?5
+             WHERE id = ?6",
+            params![new_name, new_email, new_phone, new_notes, now, client_id],
+        )?;
+
+        // Sync denormalized client_name in all projects linked to this client
+        if name_changed {
+            conn.execute(
+                "UPDATE projects SET client_name = ?1, updated_at = ?2 WHERE client_id = ?3",
+                params![new_name, now, client_id],
+            )?;
+        }
+
+        Ok(())
+    })
+    .map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("UNIQUE constraint failed") {
+            format!("A client named '{new_name}' already exists")
+        } else {
+            format!("Failed to update client: {msg}")
+        }
+    })?;
+
+    get_client_by_id(&db, &client_id).map_err(String::from)
+}
+
+/// Archive or unarchive a client.
+#[tauri::command]
+pub async fn update_client_status(
+    db: tauri::State<'_, Database>,
+    client_id: String,
+    status: ClientStatus,
+) -> Result<Client, String> {
+    let now = chrono::Utc::now().to_rfc3339();
+
+    db.execute(|conn| {
+        conn.execute(
+            "UPDATE clients SET status = ?1, updated_at = ?2 WHERE id = ?3",
+            params![status.to_string(), now, client_id],
+        )?;
+        Ok(())
+    })
+    .map_err(|e| format!("Failed to update client status: {e}"))?;
+
+    get_client_by_id(&db, &client_id).map_err(String::from)
+}
+
+/// Delete a client. Fails if the client has any associated projects.
+#[tauri::command]
+pub async fn delete_client(
+    db: tauri::State<'_, Database>,
+    client_id: String,
+) -> Result<(), String> {
+    let project_count: i64 = db
+        .execute(|conn| {
+            Ok(conn.query_row(
+                "SELECT COUNT(*) FROM projects WHERE client_id = ?1",
+                params![client_id],
+                |row| row.get(0),
+            )?)
+        })
+        .map_err(|e| format!("Database error: {e}"))?;
+
+    if project_count > 0 {
+        return Err(format!(
+            "Cannot delete client: {project_count} project(s) are still linked. Delete them first."
+        ));
+    }
+
+    db.execute(|conn| {
+        conn.execute("DELETE FROM clients WHERE id = ?1", params![client_id])?;
+        Ok(())
+    })
+    .map_err(|e| format!("Failed to delete client: {e}"))?;
+
+    Ok(())
+}
+
+/// Search clients by name or email (case-insensitive).
+#[tauri::command]
+pub async fn search_clients(
+    db: tauri::State<'_, Database>,
+    query: String,
+) -> Result<Vec<Client>, String> {
+    let pattern = format!("%{}%", query.to_lowercase());
+
+    db.execute(|conn| {
+        let mut stmt = conn.prepare(
+            "SELECT id, name, email, phone, notes, status, created_at, updated_at
+             FROM clients
+             WHERE status = 'active'
+               AND (LOWER(name) LIKE ?1 OR LOWER(COALESCE(email, '')) LIKE ?1)
+             ORDER BY name ASC",
+        )?;
+        let clients = stmt
+            .query_map(params![pattern], map_client_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(clients)
+    })
+    .map_err(|e| format!("Database error: {e}"))
+}
+
+/// One-time migration: extract unique client names from projects and create client records.
+/// Updates `projects.client_id` to reference the newly created clients.
+/// Safe to call multiple times — skips projects that already have `client_id` set.
+#[tauri::command]
+pub async fn migrate_clients_from_projects(db: tauri::State<'_, Database>) -> Result<(), String> {
+    let now = chrono::Utc::now().to_rfc3339();
+
+    db.execute(|conn| {
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT client_name FROM projects
+             WHERE client_id IS NULL AND client_name != ''",
+        )?;
+        let names: Vec<String> = stmt
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for name in names {
+            let existing_id: Option<String> = conn
+                .query_row(
+                    "SELECT id FROM clients WHERE LOWER(name) = LOWER(?1)",
+                    params![name],
+                    |row| row.get(0),
+                )
+                .ok();
+
+            let client_id = if let Some(id) = existing_id {
+                id
+            } else {
+                let id = Uuid::new_v4().to_string();
+                conn.execute(
+                    "INSERT INTO clients (id, name, status, created_at, updated_at)
+                     VALUES (?1, ?2, 'active', ?3, ?4)",
+                    params![id, name, now, now],
+                )?;
+                id
+            };
+
+            conn.execute(
+                "UPDATE projects SET client_id = ?1
+                 WHERE client_id IS NULL AND LOWER(client_name) = LOWER(?2)",
+                params![client_id, name],
+            )?;
+        }
+
+        Ok(())
+    })
+    .map_err(|e| format!("Migration failed: {e}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::db::Database;
+    use tempfile::TempDir;
+
+    fn setup_test_db() -> (TempDir, Database) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new_with_path(&db_path).unwrap();
+        (temp_dir, db)
+    }
+
+    fn insert_client(db: &Database, id: &str, name: &str) {
+        db.execute(|conn| {
+            conn.execute(
+                "INSERT INTO clients (id, name, status, created_at, updated_at)
+                 VALUES (?1, ?2, 'active', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+                params![id, name],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    fn insert_project_with_client(
+        db: &Database,
+        project_id: &str,
+        client_id: &str,
+        client_name: &str,
+    ) {
+        db.execute(|conn| {
+            conn.execute(
+                "INSERT INTO projects (id, name, client_name, client_id, date, shoot_type, status,
+                  folder_path, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, '2024-01-01', 'Wedding', 'New',
+                  '/path', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+                params![project_id, "Test Project", client_name, client_id],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_client_status_to_string() {
+        assert_eq!(ClientStatus::Active.to_string(), "active");
+        assert_eq!(ClientStatus::Archived.to_string(), "archived");
+    }
+
+    #[test]
+    fn test_client_status_from_str() {
+        assert_eq!(
+            "active".parse::<ClientStatus>().unwrap(),
+            ClientStatus::Active
+        );
+        assert_eq!(
+            "archived".parse::<ClientStatus>().unwrap(),
+            ClientStatus::Archived
+        );
+        assert!("invalid".parse::<ClientStatus>().is_err());
+    }
+
+    #[test]
+    fn test_validate_email_valid() {
+        assert!(validate_email("user@example.com"));
+        assert!(validate_email("user.name@domain.co.uk"));
+        assert!(validate_email("test@sub.domain.org"));
+    }
+
+    #[test]
+    fn test_validate_email_invalid() {
+        assert!(!validate_email("notanemail"));
+        assert!(!validate_email("missing@tld"));
+        assert!(!validate_email("@nodomain.com"));
+        assert!(!validate_email("two@@domain.com"));
+        assert!(!validate_email("spaces here@domain.com"));
+    }
+
+    #[test]
+    fn test_create_client_inserts_record() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Alice Smith");
+
+        let client = get_client_by_id(&db, "c1").unwrap();
+        assert_eq!(client.name, "Alice Smith");
+        assert_eq!(client.status, ClientStatus::Active);
+        assert!(client.email.is_none());
+    }
+
+    #[test]
+    fn test_unique_constraint_on_name() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Alice Smith");
+
+        let result = db.execute(|conn| {
+            conn.execute(
+                "INSERT INTO clients (id, name, status, created_at, updated_at)
+                 VALUES (?1, ?2, 'active', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+                params!["c2", "Alice Smith"],
+            )?;
+            Ok(())
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_list_clients_excludes_archived_by_default() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Active Client");
+        db.execute(|conn| {
+            conn.execute(
+                "INSERT INTO clients (id, name, status, created_at, updated_at)
+                 VALUES ('c2', 'Archived Client', 'archived',
+                  '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let clients = db
+            .execute(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, email, phone, notes, status, created_at, updated_at
+                     FROM clients WHERE status = 'active' ORDER BY name ASC",
+                )?;
+                let rows = stmt
+                    .query_map([], map_client_row)?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .unwrap();
+
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].name, "Active Client");
+    }
+
+    #[test]
+    fn test_search_clients_case_insensitive() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Alice Smith");
+        insert_client(&db, "c2", "Bob Jones");
+
+        let pattern = "%alice%";
+        let clients = db
+            .execute(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, email, phone, notes, status, created_at, updated_at
+                     FROM clients WHERE status = 'active'
+                     AND (LOWER(name) LIKE ?1 OR LOWER(COALESCE(email, '')) LIKE ?1)
+                     ORDER BY name ASC",
+                )?;
+                let rows = stmt
+                    .query_map(params![pattern], map_client_row)?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .unwrap();
+
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].name, "Alice Smith");
+    }
+
+    #[test]
+    fn test_delete_client_with_projects_blocked() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Alice Smith");
+        insert_project_with_client(&db, "p1", "c1", "Alice Smith");
+
+        let count: i64 = db
+            .execute(|conn| {
+                Ok(conn.query_row(
+                    "SELECT COUNT(*) FROM projects WHERE client_id = ?1",
+                    params!["c1"],
+                    |row| row.get(0),
+                )?)
+            })
+            .unwrap();
+
+        // delete_client should refuse when count > 0
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_delete_client_without_projects_succeeds() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Alice Smith");
+
+        db.execute(|conn| {
+            conn.execute("DELETE FROM clients WHERE id = ?1", params!["c1"])?;
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(get_client_by_id(&db, "c1").is_err());
+    }
+
+    #[test]
+    fn test_update_client_syncs_project_client_name() {
+        let (_temp_dir, db) = setup_test_db();
+        insert_client(&db, "c1", "Alice Smith");
+        insert_project_with_client(&db, "p1", "c1", "Alice Smith");
+
+        let now = chrono::Utc::now().to_rfc3339();
+        db.execute(|conn| {
+            conn.execute(
+                "UPDATE clients SET name = ?1, updated_at = ?2 WHERE id = ?3",
+                params!["Alice Johnson", now, "c1"],
+            )?;
+            conn.execute(
+                "UPDATE projects SET client_name = ?1, updated_at = ?2 WHERE client_id = ?3",
+                params!["Alice Johnson", now, "c1"],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let client_name: String = db
+            .execute(|conn| {
+                Ok(conn.query_row(
+                    "SELECT client_name FROM projects WHERE id = ?1",
+                    params!["p1"],
+                    |row| row.get(0),
+                )?)
+            })
+            .unwrap();
+
+        assert_eq!(client_name, "Alice Johnson");
+    }
+
+    #[test]
+    fn test_migrate_clients_from_projects() {
+        let (_temp_dir, db) = setup_test_db();
+
+        db.execute(|conn| {
+            conn.execute(
+                "INSERT INTO projects (id, name, client_name, date, shoot_type, status,
+                  folder_path, created_at, updated_at)
+                 VALUES ('p1', 'Proj1', 'Alice', '2024-01-01', 'Wedding', 'New',
+                  '/path', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO projects (id, name, client_name, date, shoot_type, status,
+                  folder_path, created_at, updated_at)
+                 VALUES ('p2', 'Proj2', 'Alice', '2024-01-02', 'Portrait', 'New',
+                  '/path2', '2024-01-02T00:00:00Z', '2024-01-02T00:00:00Z')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO projects (id, name, client_name, date, shoot_type, status,
+                  folder_path, created_at, updated_at)
+                 VALUES ('p3', 'Proj3', 'Bob', '2024-01-03', 'Event', 'New',
+                  '/path3', '2024-01-03T00:00:00Z', '2024-01-03T00:00:00Z')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let now = chrono::Utc::now().to_rfc3339();
+
+        db.execute(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT DISTINCT client_name FROM projects
+                 WHERE client_id IS NULL AND client_name != ''",
+            )?;
+            let names: Vec<String> = stmt
+                .query_map([], |row| row.get(0))?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            for name in names {
+                let id = Uuid::new_v4().to_string();
+                conn.execute(
+                    "INSERT INTO clients (id, name, status, created_at, updated_at)
+                     VALUES (?1, ?2, 'active', ?3, ?4)",
+                    params![id, name, now, now],
+                )?;
+                conn.execute(
+                    "UPDATE projects SET client_id = ?1
+                     WHERE client_id IS NULL AND LOWER(client_name) = LOWER(?2)",
+                    params![id, name],
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        let client_count: i64 = db
+            .execute(|conn| {
+                Ok(conn.query_row("SELECT COUNT(*) FROM clients", [], |row| row.get(0))?)
+            })
+            .unwrap();
+        assert_eq!(client_count, 2);
+
+        let unlinked: i64 = db
+            .execute(|conn| {
+                Ok(conn.query_row(
+                    "SELECT COUNT(*) FROM projects WHERE client_id IS NULL",
+                    [],
+                    |row| row.get(0),
+                )?)
+            })
+            .unwrap();
+        assert_eq!(unlinked, 0);
+
+        let alice_ids: Vec<String> = db
+            .execute(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT DISTINCT client_id FROM projects WHERE client_name = 'Alice'",
+                )?;
+                let rows = stmt
+                    .query_map([], |row| row.get(0))?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .unwrap();
+        assert_eq!(alice_ids.len(), 1);
+    }
+}

--- a/src-tauri/src/modules/db.rs
+++ b/src-tauri/src/modules/db.rs
@@ -34,6 +34,31 @@ impl Database {
 
     /// Initialize database schema
     fn init_schema(conn: &Connection) -> Result<(), AppError> {
+        // Create clients table
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS clients (
+                id TEXT PRIMARY KEY,
+                name TEXT UNIQUE NOT NULL,
+                email TEXT,
+                phone TEXT,
+                notes TEXT,
+                status TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_clients_name ON clients(name)",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_clients_status ON clients(status)",
+            [],
+        )?;
+
         // Create projects table
         conn.execute(
             "CREATE TABLE IF NOT EXISTS projects (
@@ -50,6 +75,17 @@ impl Database {
             )",
             [],
         )?;
+
+        // Migration: add client_id column to existing projects tables
+        let add_client_id = conn.execute(
+            "ALTER TABLE projects ADD COLUMN client_id TEXT REFERENCES clients(id)",
+            [],
+        );
+        if let Err(e) = add_client_id {
+            if !e.to_string().contains("duplicate column") {
+                return Err(e.into());
+            }
+        }
 
         // Create indexes for common queries
         conn.execute(
@@ -88,6 +124,11 @@ impl Database {
 
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_projects_client_name ON projects(client_name)",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_projects_client_id ON projects(client_id)",
             [],
         )?;
 
@@ -178,6 +219,25 @@ mod tests {
         assert!(indexes.contains(&"idx_projects_updated_at".to_owned()));
         assert!(indexes.contains(&"idx_projects_date".to_owned()));
         assert!(indexes.contains(&"idx_projects_client_name".to_owned()));
+        assert!(indexes.contains(&"idx_projects_client_id".to_owned()));
+    }
+
+    #[test]
+    fn test_schema_initialization_creates_clients_table() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new_with_path(&db_path).unwrap();
+
+        let exists = db
+            .execute(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='clients'",
+                )?;
+                Ok(stmt.exists([])?)
+            })
+            .unwrap();
+
+        assert!(exists);
     }
 
     #[test]

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod archive;
 pub mod backup;
+pub mod client;
 pub mod db;
 pub mod delivery;
 pub mod file_copy;

--- a/src-tauri/src/modules/project.rs
+++ b/src-tauri/src/modules/project.rs
@@ -28,6 +28,8 @@ pub struct Project {
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deadline: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
 }
 
 /// Workflow stage of a project from creation through archiving.
@@ -79,8 +81,8 @@ fn sanitize_path_component(s: &str) -> String {
         .collect()
 }
 
-/// Map a database row to a Project struct
-fn map_project_row(row: &rusqlite::Row) -> rusqlite::Result<Project> {
+/// Map a database row to a `Project`.
+pub fn map_project_row(row: &rusqlite::Row) -> rusqlite::Result<Project> {
     let status_str: String = row.get(5)?;
     let status = status_str.parse::<ProjectStatus>().map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(
@@ -101,6 +103,7 @@ fn map_project_row(row: &rusqlite::Row) -> rusqlite::Result<Project> {
         created_at: row.get(7)?,
         updated_at: row.get(8)?,
         deadline: row.get(9)?,
+        client_id: row.get(10)?,
     })
 }
 
@@ -113,11 +116,35 @@ pub async fn create_project(
     date: String,
     shoot_type: String,
     deadline: Option<String>,
+    client_id: Option<String>,
 ) -> Result<Project, String> {
     let id = Uuid::new_v4().to_string();
 
+    // When client_id is provided, look up the canonical client name
+    let resolved_client_name = if let Some(ref cid) = client_id {
+        let looked_up = db
+            .execute(|conn| {
+                conn.query_row(
+                    "SELECT name FROM clients WHERE id = ?1",
+                    params![cid],
+                    |row| row.get::<_, String>(0),
+                )
+                .map_err(|e| {
+                    if e == rusqlite::Error::QueryReturnedNoRows {
+                        AppError::InvalidData(format!("Client not found: {cid}"))
+                    } else {
+                        AppError::from(e)
+                    }
+                })
+            })
+            .map_err(|e| format!("Failed to look up client: {e}"))?;
+        looked_up
+    } else {
+        client_name
+    };
+
     // Create folder structure: YYYY-MM-DD_ClientName[_ProjectType]/[RAW, Selects, Delivery]
-    let sanitized_client = sanitize_path_component(&client_name);
+    let sanitized_client = sanitize_path_component(&resolved_client_name);
     let folder_name = if shoot_type.is_empty() {
         format!("{date}_{sanitized_client}")
     } else {
@@ -142,7 +169,7 @@ pub async fn create_project(
     let project = Project {
         id,
         name,
-        client_name,
+        client_name: resolved_client_name,
         date,
         shoot_type,
         status: ProjectStatus::New,
@@ -150,13 +177,15 @@ pub async fn create_project(
         created_at: now.clone(),
         updated_at: now,
         deadline: deadline.filter(|d| !d.is_empty()),
+        client_id,
     };
 
     // Insert into database
     db.execute(|conn| {
         conn.execute(
-            "INSERT INTO projects (id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            "INSERT INTO projects (id, name, client_name, date, shoot_type, status, folder_path,
+              created_at, updated_at, deadline, client_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 &project.id,
                 &project.name,
@@ -168,6 +197,7 @@ pub async fn create_project(
                 &project.created_at,
                 &project.updated_at,
                 &project.deadline,
+                &project.client_id,
             ],
         )?;
         Ok(())
@@ -182,7 +212,7 @@ pub async fn create_project(
 pub async fn list_projects(db: tauri::State<'_, Database>) -> Result<Vec<Project>, String> {
     db.execute(|conn| {
         let mut stmt = conn
-            .prepare("SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline FROM projects ORDER BY updated_at DESC")?;
+            .prepare("SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline, client_id FROM projects ORDER BY updated_at DESC")?;
 
         let projects = stmt
             .query_map([], map_project_row)?
@@ -281,7 +311,7 @@ pub async fn update_project_deadline(
 fn get_project_by_id(db: &Database, project_id: &str) -> Result<Project, AppError> {
     db.execute(|conn| {
         let mut stmt = conn
-            .prepare("SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline FROM projects WHERE id = ?1")?;
+            .prepare("SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline, client_id FROM projects WHERE id = ?1")?;
 
         stmt.query_row(params![project_id], map_project_row).map_err(|e| {
             if e == rusqlite::Error::QueryReturnedNoRows {
@@ -415,6 +445,7 @@ mod tests {
             created_at: "2024-01-15T10:00:00Z".to_owned(),
             updated_at: "2024-01-15T10:00:00Z".to_owned(),
             deadline: Some("2024-02-01".to_owned()),
+            client_id: None,
         };
 
         let json = serde_json::to_string(&project).unwrap();
@@ -487,7 +518,7 @@ mod tests {
         let projects = db
             .execute(|conn| {
                 let mut stmt = conn.prepare(
-                    "SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline FROM projects ORDER BY updated_at DESC",
+                    "SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline, client_id FROM projects ORDER BY updated_at DESC",
                 )?;
                 let projects = stmt
                     .query_map([], map_project_row)?
@@ -545,7 +576,7 @@ mod tests {
         let projects = db
             .execute(|conn| {
                 let mut stmt = conn.prepare(
-                    "SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline FROM projects ORDER BY updated_at DESC",
+                    "SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline, client_id FROM projects ORDER BY updated_at DESC",
                 )?;
                 let projects = stmt
                     .query_map([], map_project_row)?
@@ -704,6 +735,7 @@ mod tests {
             created_at: "2024-01-15T10:00:00Z".to_owned(),
             updated_at: "2024-01-15T10:00:00Z".to_owned(),
             deadline: Some("2024-07-01".to_owned()),
+            client_id: None,
         };
 
         assert_eq!(project.id, "test-123");
@@ -726,6 +758,7 @@ mod tests {
             created_at: "2024-01-15T10:00:00Z".to_owned(),
             updated_at: "2024-01-15T10:00:00Z".to_owned(),
             deadline: None,
+            client_id: None,
         };
 
         assert_eq!(project.deadline, None);
@@ -754,6 +787,7 @@ mod tests {
                 created_at: "2024-01-01T00:00:00Z".to_owned(),
                 updated_at: "2024-01-01T00:00:00Z".to_owned(),
                 deadline: None,
+                client_id: None,
             };
 
             assert_eq!(project.status, status);
@@ -838,7 +872,7 @@ mod tests {
 
         let projects = db.execute(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline FROM projects ORDER BY updated_at DESC"
+                "SELECT id, name, client_name, date, shoot_type, status, folder_path, created_at, updated_at, deadline, client_id FROM projects ORDER BY updated_at DESC"
             )?;
             let projects = stmt
                 .query_map([], map_project_row)?

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 
 import { CommandPalette } from './components/CommandPalette'
+import { Clients } from './components/Clients'
 import { Dashboard } from './components/Dashboard'
 import { BackupQueue } from './components/BackupQueue'
 import { Delivery } from './components/Delivery'
@@ -18,14 +19,29 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useNotification } from './hooks/useNotification'
 import { useSDCardScanner } from './hooks/useSDCardScanner'
 import { useTheme } from './hooks/useTheme'
-import type { Project } from './types'
+import type { Client, Project } from './types'
 
-type View = 'dashboard' | 'import' | 'projects' | 'backup' | 'delivery' | 'history' | 'settings'
+type View =
+  | 'dashboard'
+  | 'import'
+  | 'projects'
+  | 'clients'
+  | 'backup'
+  | 'delivery'
+  | 'history'
+  | 'settings'
 
 function isView(value: string): value is View {
-  return ['dashboard', 'import', 'projects', 'backup', 'delivery', 'history', 'settings'].includes(
-    value
-  )
+  return [
+    'dashboard',
+    'import',
+    'projects',
+    'clients',
+    'backup',
+    'delivery',
+    'history',
+    'settings',
+  ].includes(value)
 }
 
 interface ViewWrapperProps {
@@ -51,6 +67,7 @@ function App() {
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>()
   const [projectsCount, setProjectsCount] = useState<number>(0)
+  const [clientsCount, setClientsCount] = useState<number>(0)
   const [viewBeforeProject, setViewBeforeProject] = useState<View>('dashboard')
   const [projectsResetKey, setProjectsResetKey] = useState<number>(0)
 
@@ -70,9 +87,19 @@ function App() {
     }
   }, [showError])
 
+  const loadClientsCount = useCallback(async () => {
+    try {
+      const clients = await invoke<Client[]>('list_clients', { includeArchived: false })
+      setClientsCount(clients.length)
+    } catch (error) {
+      console.error('Failed to load client count:', error)
+    }
+  }, [])
+
   useEffect(() => {
     void loadProjectCount()
-  }, [loadProjectCount])
+    void loadClientsCount()
+  }, [loadProjectCount, loadClientsCount])
 
   // Global SD card scanner - runs in background across all pages
   const { sdCards, isScanning, scanForSDCards } = useSDCardScanner({
@@ -119,21 +146,27 @@ function App() {
         metaKey: true,
       },
       {
+        action: () => setCurrentView('clients'),
+        description: 'Go to Clients',
+        key: '4',
+        metaKey: true,
+      },
+      {
         action: () => setCurrentView('backup'),
         description: 'Go to Backup Queue',
-        key: '4',
+        key: '5',
         metaKey: true,
       },
       {
         action: () => setCurrentView('delivery'),
         description: 'Go to Delivery',
-        key: '5',
+        key: '6',
         metaKey: true,
       },
       {
         action: () => setCurrentView('history'),
         description: 'Go to History',
-        key: '6',
+        key: '7',
         metaKey: true,
       },
       {
@@ -173,9 +206,12 @@ function App() {
     if (isView(view)) {
       setCurrentView(view)
     }
-    // Refresh count when switching to views that show projects
+    // Refresh counts when switching to relevant views
     if (view === 'dashboard' || view === 'projects') {
       void loadProjectCount()
+    }
+    if (view === 'clients') {
+      void loadClientsCount()
     }
   }
 
@@ -186,6 +222,7 @@ function App() {
         onNavigate={handleViewChange}
         importCount={sdCards.length}
         projectsCount={projectsCount}
+        clientsCount={clientsCount}
       >
         <ViewWrapper isActive={currentView === 'dashboard'} name="Dashboard">
           <Dashboard
@@ -207,6 +244,9 @@ function App() {
             isActive={currentView === 'projects'}
             onBackFromProject={handleBackFromProject}
           />
+        </ViewWrapper>
+        <ViewWrapper isActive={currentView === 'clients'} name="Clients">
+          <Clients isActive={currentView === 'clients'} />
         </ViewWrapper>
         <ViewWrapper isActive={currentView === 'backup'} name="Backup Queue">
           <BackupQueue isActive={currentView === 'backup'} />

--- a/src/components/ClientSelector.test.tsx
+++ b/src/components/ClientSelector.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { invoke } from '@tauri-apps/api/core'
+import { ClientSelector } from './ClientSelector'
+import type { Client } from '../types'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const mockInvoke = vi.mocked(invoke)
+
+const mockClients: Client[] = [
+  {
+    createdAt: '2025-01-01T00:00:00Z',
+    id: 'c1',
+    name: 'Alice Smith',
+    status: 'active',
+    updatedAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    createdAt: '2025-01-01T00:00:00Z',
+    email: 'bob@example.com',
+    id: 'c2',
+    name: 'Bob Jones',
+    status: 'active',
+    updatedAt: '2025-01-01T00:00:00Z',
+  },
+]
+
+describe('ClientSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(mockClients)
+  })
+
+  it('renders input field', async () => {
+    render(<ClientSelector clientId={null} onChange={vi.fn()} value="" />)
+    expect(screen.getByRole('textbox')).toBeTruthy()
+  })
+
+  it('loads clients on mount', async () => {
+    render(<ClientSelector clientId={null} onChange={vi.fn()} value="" />)
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('list_clients', { includeArchived: false })
+    })
+  })
+
+  it('shows dropdown with matching clients on input', async () => {
+    const user = userEvent.setup()
+    render(<ClientSelector clientId={null} onChange={vi.fn()} value="" />)
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'Ali')
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeTruthy()
+    })
+    expect(screen.queryByText('Bob Jones')).toBeNull()
+  })
+
+  it('calls onChange with client data on selection', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ClientSelector clientId={null} onChange={onChange} value="" />)
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'Alice')
+
+    await waitFor(() => screen.getByText('Alice Smith'))
+    await user.click(screen.getByText('Alice Smith'))
+
+    expect(onChange).toHaveBeenCalledWith('Alice Smith', 'c1')
+  })
+
+  it('shows create option when query has no exact match', async () => {
+    const user = userEvent.setup()
+    render(<ClientSelector clientId={null} onChange={vi.fn()} value="" />)
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'New Client')
+
+    await waitFor(() => {
+      expect(screen.getByText(/Create.*New Client/)).toBeTruthy()
+    })
+  })
+
+  it('shows client email in dropdown', async () => {
+    const user = userEvent.setup()
+    render(<ClientSelector clientId={null} onChange={vi.fn()} value="" />)
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'Bob')
+
+    await waitFor(() => {
+      expect(screen.getByText('bob@example.com')).toBeTruthy()
+    })
+  })
+})

--- a/src/components/ClientSelector.tsx
+++ b/src/components/ClientSelector.tsx
@@ -58,9 +58,10 @@ export function ClientSelector({ value, clientId, onChange, required }: ClientSe
     const val = e.target.value
     setQuery(val)
     setIsOpen(true)
-    // If user clears the field or types something that doesn't match selected client,
-    // clear the clientId association
-    if (!clientId || val !== value) {
+    const exactMatch = clients.find((c) => c.name.toLowerCase() === val.trim().toLowerCase())
+    if (exactMatch) {
+      onChange(exactMatch.name, exactMatch.id)
+    } else {
       onChange(val, null)
     }
   }

--- a/src/components/ClientSelector.tsx
+++ b/src/components/ClientSelector.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import type { Client } from '../types'
+import { CreateClient } from './CreateClient'
+
+interface ClientSelectorProps {
+  value: string
+  clientId: string | null
+  onChange: (clientName: string, clientId: string | null) => void
+  required?: boolean
+}
+
+export function ClientSelector({ value, clientId, onChange, required }: ClientSelectorProps) {
+  const [clients, setClients] = useState<Client[]>([])
+  const [query, setQuery] = useState(value)
+  const [isOpen, setIsOpen] = useState(false)
+  const [showCreateClient, setShowCreateClient] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const loadClients = useCallback(async () => {
+    try {
+      const result = await invoke<Client[]>('list_clients', { includeArchived: false })
+      setClients(result)
+    } catch {
+      setClients([])
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadClients()
+  }, [loadClients])
+
+  // Keep local query in sync when parent value changes externally
+  useEffect(() => {
+    setQuery(value)
+  }, [value])
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  const filtered = clients.filter((c) => c.name.toLowerCase().includes(query.toLowerCase()))
+
+  const handleSelect = (client: Client) => {
+    setQuery(client.name)
+    setIsOpen(false)
+    onChange(client.name, client.id)
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setQuery(val)
+    setIsOpen(true)
+    // If user clears the field or types something that doesn't match selected client,
+    // clear the clientId association
+    if (!clientId || val !== value) {
+      onChange(val, null)
+    }
+  }
+
+  const handleClientCreated = (client: Client) => {
+    setClients((prev) => [...prev, client].sort((a, b) => a.name.localeCompare(b.name)))
+    setQuery(client.name)
+    setIsOpen(false)
+    setShowCreateClient(false)
+    onChange(client.name, client.id)
+  }
+
+  const showCreateOption =
+    query.trim().length > 0 &&
+    !clients.some((c) => c.name.toLowerCase() === query.trim().toLowerCase())
+
+  if (showCreateClient) {
+    return (
+      <div className="client-selector-create">
+        <div className="flex flex-col gap-xxs" style={{ marginBottom: 'var(--space-sm)' }}>
+          <span className="form-label">Creating new client: &ldquo;{query}&rdquo;</span>
+        </div>
+        <CreateClient
+          onClientCreated={handleClientCreated}
+          onCancel={() => setShowCreateClient(false)}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="client-selector">
+      <input
+        id="clientSelector"
+        type="text"
+        className="input"
+        value={query}
+        onChange={handleInputChange}
+        onFocus={() => setIsOpen(true)}
+        placeholder="Search or type client name"
+        required={required}
+        autoComplete="off"
+      />
+      {isOpen && (filtered.length > 0 || showCreateOption) && (
+        <div className="client-selector-dropdown">
+          {filtered.map((client) => (
+            <div
+              key={client.id}
+              className="client-selector-option"
+              onMouseDown={() => handleSelect(client)}
+              role="option"
+              tabIndex={0}
+              aria-selected={client.id === clientId}
+            >
+              <span className="client-selector-name">{client.name}</span>
+              {client.email && (
+                <span className="client-selector-email text-secondary">{client.email}</span>
+              )}
+            </div>
+          ))}
+          {showCreateOption && (
+            <div
+              className="client-selector-option client-selector-create-option"
+              onMouseDown={() => {
+                setIsOpen(false)
+                setShowCreateClient(true)
+              }}
+              role="option"
+              tabIndex={0}
+              aria-selected={false}
+            >
+              + Create &ldquo;{query}&rdquo;
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Clients.test.tsx
+++ b/src/components/Clients.test.tsx
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { invoke } from '@tauri-apps/api/core'
+import { NotificationProvider } from '../contexts/NotificationContext'
+import { Clients } from './Clients'
+import type { Client, ClientWithProjects } from '../types'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const mockInvoke = vi.mocked(invoke)
+
+const mockClients: Client[] = [
+  {
+    createdAt: '2025-01-01T00:00:00Z',
+    email: 'alice@example.com',
+    id: 'c1',
+    name: 'Alice Smith',
+    status: 'active',
+    updatedAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    createdAt: '2025-01-01T00:00:00Z',
+    id: 'c2',
+    name: 'Bob Jones',
+    status: 'active',
+    updatedAt: '2025-01-01T00:00:00Z',
+  },
+]
+
+const mockClientDetail: ClientWithProjects = {
+  ...mockClients[0],
+  projects: [],
+}
+
+describe('Clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(mockClients)
+  })
+
+  it('shows loading initially', () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}))
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+    expect(screen.getByText('Loading...')).toBeTruthy()
+  })
+
+  it('renders client list after loading', async () => {
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeTruthy()
+      expect(screen.getByText('Bob Jones')).toBeTruthy()
+    })
+  })
+
+  it('shows empty state when no clients', async () => {
+    mockInvoke.mockResolvedValue([])
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByText('No clients yet')).toBeTruthy()
+    })
+  })
+
+  it('filters clients by search query', async () => {
+    const user = userEvent.setup()
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+
+    await waitFor(() => screen.getByText('Alice Smith'))
+
+    await user.type(screen.getByPlaceholderText('Search clients...'), 'Alice')
+
+    expect(screen.getByText('Alice Smith')).toBeTruthy()
+    expect(screen.queryByText('Bob Jones')).toBeNull()
+  })
+
+  it('opens create client dialog', async () => {
+    const user = userEvent.setup()
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+
+    await waitFor(() => screen.getByText('Alice Smith'))
+    await user.click(screen.getByText('Create Client'))
+
+    expect(screen.getByText('Create New Client')).toBeTruthy()
+  })
+
+  it('navigates to client detail on click', async () => {
+    mockInvoke.mockResolvedValueOnce(mockClients).mockResolvedValueOnce(mockClientDetail)
+
+    const user = userEvent.setup()
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+
+    await waitFor(() => screen.getByText('Alice Smith'))
+    await user.click(screen.getByText('Alice Smith'))
+
+    await waitFor(() => {
+      expect(screen.getByText('← Back')).toBeTruthy()
+      expect(screen.getByText('Projects (0)')).toBeTruthy()
+    })
+  })
+
+  it('returns to list on back button click', async () => {
+    mockInvoke
+      .mockResolvedValueOnce(mockClients)
+      .mockResolvedValueOnce(mockClientDetail)
+      .mockResolvedValueOnce(mockClients)
+
+    const user = userEvent.setup()
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+
+    await waitFor(() => screen.getByText('Alice Smith'))
+    await user.click(screen.getByText('Alice Smith'))
+    await waitFor(() => screen.getByText('← Back'))
+    await user.click(screen.getByText('← Back'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('← Back')).toBeNull()
+    })
+  })
+
+  it('shows email in client card', async () => {
+    render(
+      <NotificationProvider>
+        <Clients />
+      </NotificationProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByText('alice@example.com')).toBeTruthy()
+    })
+  })
+})

--- a/src/components/Clients.tsx
+++ b/src/components/Clients.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useEffect, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import type { Client, ClientWithProjects } from '../types'
+import { useNotification } from '../hooks/useNotification'
+import { CreateClient } from './CreateClient'
+
+type FilterMode = 'active' | 'archived' | 'all'
+
+interface ClientsProps {
+  isActive?: boolean
+}
+
+export function Clients({ isActive }: ClientsProps) {
+  const { error: showError, success } = useNotification()
+  const [clients, setClients] = useState<Client[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedClient, setSelectedClient] = useState<ClientWithProjects | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filterMode, setFilterMode] = useState<FilterMode>('active')
+  const [showCreateClient, setShowCreateClient] = useState(false)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const loadClients = useCallback(async () => {
+    try {
+      setLoading(true)
+      const includeArchived = filterMode !== 'active'
+      const result = await invoke<Client[]>('list_clients', { includeArchived })
+      const filtered = filterMode === 'all' ? result : result.filter((c) => c.status === filterMode)
+      setClients(filtered)
+    } catch (err) {
+      console.error('Failed to load clients:', err)
+      if (isActive) showError('Failed to load clients')
+    } finally {
+      setLoading(false)
+    }
+  }, [filterMode, isActive, showError])
+
+  useEffect(() => {
+    void loadClients()
+  }, [loadClients])
+
+  const handleSelectClient = async (client: Client) => {
+    try {
+      const detail = await invoke<ClientWithProjects>('get_client', { clientId: client.id })
+      setSelectedClient(detail)
+    } catch (err) {
+      console.error('Failed to load client detail:', err)
+      showError('Failed to load client details')
+    }
+  }
+
+  const handleBack = () => {
+    setSelectedClient(null)
+    setShowDeleteDialog(false)
+  }
+
+  const handleClientCreated = (client: Client) => {
+    setShowCreateClient(false)
+    void loadClients()
+    void handleSelectClient(client)
+  }
+
+  const handleArchiveToggle = async () => {
+    if (!selectedClient) return
+    const newStatus = selectedClient.status === 'active' ? 'archived' : 'active'
+    try {
+      await invoke<Client>('update_client_status', {
+        clientId: selectedClient.id,
+        status: newStatus,
+      })
+      success(newStatus === 'archived' ? 'Client archived' : 'Client restored')
+      void loadClients()
+      setSelectedClient(null)
+    } catch (err) {
+      console.error('Failed to update client status:', err)
+      showError('Failed to update client status')
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!selectedClient) return
+    setIsDeleting(true)
+    try {
+      await invoke<void>('delete_client', { clientId: selectedClient.id })
+      success('Client deleted')
+      setShowDeleteDialog(false)
+      setSelectedClient(null)
+      void loadClients()
+    } catch (err) {
+      console.error('Failed to delete client:', err)
+      showError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  const displayedClients = clients.filter(
+    (c) =>
+      c.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      c.email?.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+
+  if (loading) {
+    return <div className="loading">Loading...</div>
+  }
+
+  if (selectedClient) {
+    return (
+      <ClientDetail
+        client={selectedClient}
+        onBack={handleBack}
+        onArchiveToggle={() => void handleArchiveToggle()}
+        onDeleteRequest={() => setShowDeleteDialog(true)}
+        showDeleteDialog={showDeleteDialog}
+        isDeleting={isDeleting}
+        onDeleteConfirm={() => void handleDelete()}
+        onDeleteCancel={() => setShowDeleteDialog(false)}
+      />
+    )
+  }
+
+  return (
+    <>
+      <div className="content-header">
+        <h1>Clients</h1>
+        <p className="text-secondary">Manage your photography clients</p>
+        <button className="btn-primary" onClick={() => setShowCreateClient(true)}>
+          Create Client
+        </button>
+      </div>
+
+      <div className="content-body">
+        <div className="flex flex-col gap-lg">
+          <div className="flex gap-md" style={{ alignItems: 'center' }}>
+            <input
+              type="text"
+              className="input"
+              placeholder="Search clients..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              style={{ flex: 1 }}
+            />
+            <div className="flex gap-xs">
+              {(['active', 'archived', 'all'] as FilterMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  className={`btn ${filterMode === mode ? 'btn-primary' : 'btn-ghost'}`}
+                  onClick={() => setFilterMode(mode)}
+                >
+                  {mode.charAt(0).toUpperCase() + mode.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {displayedClients.length === 0 ? (
+            <div className="empty-state">
+              <p className="text-secondary">
+                {searchQuery ? 'No clients match your search' : 'No clients yet'}
+              </p>
+              {!searchQuery && (
+                <p className="text-secondary text-sm">Click Create Client to get started</p>
+              )}
+            </div>
+          ) : (
+            <div className="client-grid">
+              {displayedClients.map((client) => (
+                <ClientCard
+                  key={client.id}
+                  client={client}
+                  onClick={() => void handleSelectClient(client)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showCreateClient && (
+        <div
+          className="dialog-overlay"
+          onClick={() => setShowCreateClient(false)}
+          role="presentation"
+        >
+          <div
+            className="dialog"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.key === 'Escape' && setShowCreateClient(false)}
+            role="dialog"
+          >
+            <h2>Create New Client</h2>
+            <CreateClient
+              onClientCreated={handleClientCreated}
+              onCancel={() => setShowCreateClient(false)}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+interface ClientCardProps {
+  client: Client
+  onClick: () => void
+}
+
+function ClientCard({ client, onClick }: ClientCardProps) {
+  return (
+    <div
+      className="client-card"
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => e.key === 'Enter' && onClick()}
+    >
+      <div className="client-card-header">
+        <h3 className="client-card-name">{client.name}</h3>
+        {client.status === 'archived' && <span className="badge badge-secondary">Archived</span>}
+      </div>
+      {client.email && <p className="text-secondary text-sm">{client.email}</p>}
+      {client.phone && <p className="text-secondary text-sm">{client.phone}</p>}
+    </div>
+  )
+}
+
+interface ClientDetailProps {
+  client: ClientWithProjects
+  onBack: () => void
+  onArchiveToggle: () => void
+  onDeleteRequest: () => void
+  showDeleteDialog: boolean
+  isDeleting: boolean
+  onDeleteConfirm: () => void
+  onDeleteCancel: () => void
+}
+
+function ClientDetail({
+  client,
+  onBack,
+  onArchiveToggle,
+  onDeleteRequest,
+  showDeleteDialog,
+  isDeleting,
+  onDeleteConfirm,
+  onDeleteCancel,
+}: ClientDetailProps) {
+  return (
+    <>
+      <div className="content-header">
+        <div className="flex gap-md" style={{ alignItems: 'center' }}>
+          <button className="btn btn-ghost" onClick={onBack}>
+            ← Back
+          </button>
+          <h1>{client.name}</h1>
+        </div>
+        <div className="flex gap-md">
+          <button className="btn btn-ghost" onClick={onArchiveToggle}>
+            {client.status === 'active' ? 'Archive' : 'Restore'}
+          </button>
+        </div>
+      </div>
+
+      <div className="content-body">
+        <div className="flex flex-col gap-xl">
+          <section className="client-detail-meta">
+            {client.email && (
+              <p>
+                <span className="text-secondary">Email: </span>
+                <a href={`mailto:${client.email}`}>{client.email}</a>
+              </p>
+            )}
+            {client.phone && (
+              <p>
+                <span className="text-secondary">Phone: </span>
+                {client.phone}
+              </p>
+            )}
+            {client.notes && (
+              <div className="client-detail-notes">
+                <p className="text-secondary" style={{ marginBottom: 'var(--space-xs)' }}>
+                  Notes
+                </p>
+                <p>{client.notes}</p>
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h2>Projects ({client.projects.length})</h2>
+            {client.projects.length === 0 ? (
+              <div className="empty-state">
+                <p className="text-secondary">No projects for this client yet</p>
+              </div>
+            ) : (
+              <div className="project-list">
+                {client.projects.map((project) => (
+                  <div key={project.id} className="project-list-item">
+                    <div className="project-list-content">
+                      <div>
+                        <h3>{project.name}</h3>
+                        <p className="text-secondary text-sm">{project.date}</p>
+                      </div>
+                      <span className="project-status">{project.status}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {client.projects.length === 0 && (
+            <section>
+              <button type="button" className="btn btn-danger" onClick={onDeleteRequest}>
+                Delete Client
+              </button>
+            </section>
+          )}
+        </div>
+      </div>
+
+      {showDeleteDialog && (
+        <div className="dialog-overlay" onClick={onDeleteCancel} role="presentation">
+          <div className="dialog" onClick={(e) => e.stopPropagation()} role="dialog">
+            <h2>Delete Client</h2>
+            <p>
+              Are you sure you want to delete <strong>{client.name}</strong>? This cannot be undone.
+            </p>
+            <div
+              className="flex gap-md"
+              style={{ justifyContent: 'flex-end', marginTop: 'var(--space-lg)' }}
+            >
+              <button className="btn btn-ghost" onClick={onDeleteCancel} disabled={isDeleting}>
+                Cancel
+              </button>
+              <button className="btn btn-danger" onClick={onDeleteConfirm} disabled={isDeleting}>
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/CreateClient.test.tsx
+++ b/src/components/CreateClient.test.tsx
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { invoke } from '@tauri-apps/api/core'
+import { CreateClient } from './CreateClient'
+import type { Client } from '../types'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const mockInvoke = vi.mocked(invoke)
+
+const mockClient: Client = {
+  createdAt: '2025-01-01T00:00:00Z',
+  id: 'c1',
+  name: 'Alice Smith',
+  status: 'active',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+describe('CreateClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders all fields', () => {
+    render(<CreateClient />)
+    expect(screen.getByLabelText(/Name/)).toBeTruthy()
+    expect(screen.getByLabelText(/Email/)).toBeTruthy()
+    expect(screen.getByLabelText(/Phone/)).toBeTruthy()
+    expect(screen.getByLabelText(/Notes/)).toBeTruthy()
+    expect(screen.getByText('Create Client')).toBeTruthy()
+  })
+
+  it('shows cancel button when onCancel provided', () => {
+    render(<CreateClient onCancel={vi.fn()} />)
+    expect(screen.getByText('Cancel')).toBeTruthy()
+  })
+
+  it('hides cancel button when onCancel not provided', () => {
+    render(<CreateClient />)
+    expect(screen.queryByText('Cancel')).toBeNull()
+  })
+
+  it('marks optional fields as optional', () => {
+    render(<CreateClient />)
+    const optionals = screen.getAllByText('(optional)')
+    expect(optionals.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('calls onClientCreated with created client on submit', async () => {
+    mockInvoke.mockResolvedValue(mockClient)
+    const onClientCreated = vi.fn()
+    const user = userEvent.setup()
+
+    render(<CreateClient onClientCreated={onClientCreated} />)
+    await user.type(screen.getByLabelText(/Name/), 'Alice Smith')
+    await user.click(screen.getByText('Create Client'))
+
+    await waitFor(() => {
+      expect(onClientCreated).toHaveBeenCalledWith(mockClient)
+    })
+  })
+
+  it('invokes create_client with correct args', async () => {
+    mockInvoke.mockResolvedValue(mockClient)
+    const user = userEvent.setup()
+
+    render(<CreateClient />)
+    await user.type(screen.getByLabelText(/Name/), 'Alice Smith')
+    await user.type(screen.getByLabelText(/Email/), 'alice@example.com')
+    await user.type(screen.getByLabelText(/Phone/), '+1 555 0100')
+    await user.click(screen.getByText('Create Client'))
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('create_client', {
+        email: 'alice@example.com',
+        name: 'Alice Smith',
+        notes: null,
+        phone: '+1 555 0100',
+      })
+    })
+  })
+
+  it('shows error on invalid email format', async () => {
+    const user = userEvent.setup()
+
+    render(<CreateClient />)
+    await user.type(screen.getByLabelText(/Name/), 'Alice Smith')
+    await user.type(screen.getByLabelText(/Email/), 'notanemail')
+    await user.click(screen.getByText('Create Client'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid email format')).toBeTruthy()
+    })
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('shows error message on invoke failure', async () => {
+    mockInvoke.mockRejectedValue(new Error("A client named 'Alice Smith' already exists"))
+    const user = userEvent.setup()
+
+    render(<CreateClient />)
+    await user.type(screen.getByLabelText(/Name/), 'Alice Smith')
+    await user.click(screen.getByText('Create Client'))
+
+    await waitFor(() => {
+      expect(screen.getByText("A client named 'Alice Smith' already exists")).toBeTruthy()
+    })
+  })
+
+  it('shows loading state during submit', async () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}))
+    const user = userEvent.setup()
+
+    render(<CreateClient />)
+    await user.type(screen.getByLabelText(/Name/), 'Alice Smith')
+    await user.click(screen.getByText('Create Client'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Creating...')).toBeTruthy()
+    })
+  })
+
+  it('prevents submit when name is empty', async () => {
+    const user = userEvent.setup()
+    render(<CreateClient />)
+    await user.click(screen.getByText('Create Client'))
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('calls onCancel when cancel clicked', async () => {
+    const onCancel = vi.fn()
+    const user = userEvent.setup()
+    render(<CreateClient onCancel={onCancel} />)
+    await user.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/CreateClient.tsx
+++ b/src/components/CreateClient.tsx
@@ -1,44 +1,52 @@
 import { useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
-import type { Project } from '../types'
-import { ClientSelector } from './ClientSelector'
-import { DatePicker } from './DatePicker'
+import type { Client } from '../types'
 
-interface CreateProjectProps {
-  onProjectCreated?: (project: Project) => void
+interface CreateClientProps {
+  onClientCreated?: (client: Client) => void
   onCancel?: () => void
 }
 
-export function CreateProject({ onProjectCreated, onCancel }: CreateProjectProps) {
-  const [formData, setFormData] = useState(() => {
-    const today = new Date().toISOString().split('T')[0]
-    return {
-      clientId: null as string | null,
-      clientName: '',
-      date: today,
-      deadline: '',
-      name: '',
-      shootType: '',
-    }
+function validateEmail(email: string): boolean {
+  const atIdx = email.indexOf('@')
+  if (atIdx <= 0) return false
+  const afterAt = email.slice(atIdx + 1)
+  if (afterAt.includes('@') || afterAt.includes(' ')) return false
+  const dotIdx = afterAt.lastIndexOf('.')
+  return dotIdx > 0 && dotIdx < afterAt.length - 1
+}
+
+export function CreateClient({ onClientCreated, onCancel }: CreateClientProps) {
+  const [formData, setFormData] = useState({
+    email: '',
+    name: '',
+    notes: '',
+    phone: '',
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!formData.name.trim()) {
+      setError('Name is required')
+      return
+    }
+    if (formData.email && !validateEmail(formData.email)) {
+      setError('Invalid email format')
+      return
+    }
     setIsSubmitting(true)
     setError(undefined)
 
     try {
-      const project = await invoke<Project>('create_project', {
-        clientId: formData.clientId,
-        clientName: formData.clientName,
-        date: formData.date,
-        deadline: formData.deadline,
+      const client = await invoke<Client>('create_client', {
+        email: formData.email || null,
         name: formData.name,
-        shootType: formData.shootType,
+        notes: formData.notes || null,
+        phone: formData.phone || null,
       })
-      onProjectCreated?.(project)
+      onClientCreated?.(client)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -46,12 +54,14 @@ export function CreateProject({ onProjectCreated, onCancel }: CreateProjectProps
     }
   }
 
-  const handleChange = <K extends keyof typeof formData>(field: K, value: (typeof formData)[K]) => {
+  const handleChange = (field: keyof typeof formData, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
+    if (field === 'email') setError(undefined)
   }
 
   return (
     <form
+      noValidate
       onSubmit={(e) => {
         e.preventDefault()
         void handleSubmit(e)
@@ -59,70 +69,59 @@ export function CreateProject({ onProjectCreated, onCancel }: CreateProjectProps
     >
       <div className="flex flex-col gap-sm">
         <div className="flex flex-col gap-xxs">
-          <label htmlFor="name" className="form-label">
-            Project Name *
+          <label htmlFor="client-name" className="form-label">
+            Name *
           </label>
           <input
-            id="name"
+            id="client-name"
             type="text"
             className="input"
             value={formData.name}
             onChange={(e) => handleChange('name', e.target.value)}
-            placeholder="e.g., Wedding Portfolio"
+            placeholder="e.g., Smith Family"
             required
           />
         </div>
 
         <div className="flex flex-col gap-xxs">
-          <label htmlFor="clientSelector" className="form-label">
-            Client Name *
-          </label>
-          <ClientSelector
-            value={formData.clientName}
-            clientId={formData.clientId}
-            onChange={(name, id) => {
-              setFormData((prev) => ({ ...prev, clientName: name, clientId: id }))
-            }}
-            required
-          />
-        </div>
-
-        <div className="flex flex-col gap-xxs">
-          <DatePicker
-            id="date"
-            label="Shoot Date"
-            value={formData.date}
-            onChange={(value) => handleChange('date', value)}
-            required
-          />
-        </div>
-
-        <hr className="form-section-separator" />
-
-        <div className="flex flex-col gap-xxs">
-          <label htmlFor="shootType" className="form-label">
-            Shoot Type <span className="text-optional">(optional)</span>
+          <label htmlFor="client-email" className="form-label">
+            Email <span className="text-optional">(optional)</span>
           </label>
           <input
-            id="shootType"
-            type="text"
+            id="client-email"
+            type="email"
             className="input"
-            value={formData.shootType}
-            onChange={(e) => handleChange('shootType', e.target.value)}
-            placeholder="e.g., Wedding, Portrait, Event"
+            value={formData.email}
+            onChange={(e) => handleChange('email', e.target.value)}
+            placeholder="e.g., smith@example.com"
           />
         </div>
 
         <div className="flex flex-col gap-xxs">
-          <DatePicker
-            id="deadline"
-            label={
-              <>
-                Deadline <span className="text-optional">(optional)</span>
-              </>
-            }
-            value={formData.deadline}
-            onChange={(value) => handleChange('deadline', value)}
+          <label htmlFor="client-phone" className="form-label">
+            Phone <span className="text-optional">(optional)</span>
+          </label>
+          <input
+            id="client-phone"
+            type="tel"
+            className="input"
+            value={formData.phone}
+            onChange={(e) => handleChange('phone', e.target.value)}
+            placeholder="e.g., +1 555 123 4567"
+          />
+        </div>
+
+        <div className="flex flex-col gap-xxs">
+          <label htmlFor="client-notes" className="form-label">
+            Notes <span className="text-optional">(optional)</span>
+          </label>
+          <textarea
+            id="client-notes"
+            className="input"
+            value={formData.notes}
+            onChange={(e) => handleChange('notes', e.target.value)}
+            placeholder="Any notes about this client"
+            rows={3}
           />
         </div>
 
@@ -161,7 +160,7 @@ export function CreateProject({ onProjectCreated, onCancel }: CreateProjectProps
               </button>
             )}
             <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
-              {isSubmitting ? 'Creating...' : 'Create Project'}
+              {isSubmitting ? 'Creating...' : 'Create Client'}
             </button>
           </div>
         </div>

--- a/src/components/CreateProject.test.tsx
+++ b/src/components/CreateProject.test.tsx
@@ -13,9 +13,23 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 const mockInvoke = vi.mocked(invoke)
 
+const mockProject: Project = {
+  clientName: 'Test Client',
+  createdAt: '2025-11-20',
+  date: '2025-11-20',
+  folderPath: '/test/path',
+  id: '123',
+  name: 'Test Project',
+  shootType: '',
+  status: ProjectStatus.Editing,
+  updatedAt: '2025-11-20',
+}
+
 describe('createProject', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // list_clients returns empty by default
+    mockInvoke.mockResolvedValue([])
   })
 
   it('renders form with all fields', () => {
@@ -51,40 +65,20 @@ describe('createProject', () => {
     expect(dateInput).toBeTruthy()
   })
 
-  it('updates form fields when typing', async () => {
+  it('updates project name when typing', async () => {
     const user = userEvent.setup()
     render(<CreateProject />)
 
     const nameInput = screen.getByLabelText(/Project Name/)
-    const clientInput = screen.getByLabelText(/Client Name/)
-    const shootTypeInput = screen.getByLabelText(/Shoot Type/)
-
     await user.type(nameInput, 'Test Project')
-    await user.type(clientInput, 'Test Client')
-    await user.type(shootTypeInput, 'Wedding')
 
     expect(nameInput).toBeInstanceOf(HTMLInputElement)
     expect(nameInput).toHaveProperty('value', 'Test Project')
-    expect(clientInput).toBeInstanceOf(HTMLInputElement)
-    expect(clientInput).toHaveProperty('value', 'Test Client')
-    expect(shootTypeInput).toBeInstanceOf(HTMLInputElement)
-    expect(shootTypeInput).toHaveProperty('value', 'Wedding')
   })
 
   it('calls onProjectCreated with created project on submit', async () => {
-    const mockProject: Project = {
-      clientName: 'Test Client',
-      createdAt: '2025-11-20',
-      date: '2025-11-20',
-      folderPath: '/test/path',
-      id: '123',
-      name: 'Test Project',
-      shootType: '',
-      status: ProjectStatus.Editing,
-      updatedAt: '2025-11-20',
-    }
-
-    mockInvoke.mockResolvedValue(mockProject)
+    mockInvoke.mockResolvedValueOnce([]) // list_clients
+    mockInvoke.mockResolvedValueOnce(mockProject) // create_project
 
     const onProjectCreated = vi.fn()
     const user = userEvent.setup()
@@ -119,7 +113,8 @@ describe('createProject', () => {
 
   it('shows loading state while submitting', async () => {
     let resolveInvoke: (value: Project) => void
-    mockInvoke.mockReturnValue(
+    mockInvoke.mockReturnValueOnce(Promise.resolve([])) // list_clients
+    mockInvoke.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveInvoke = resolve
       })
@@ -155,7 +150,8 @@ describe('createProject', () => {
   })
 
   it('disables buttons while submitting', async () => {
-    mockInvoke.mockReturnValue(new Promise(() => {}))
+    mockInvoke.mockReturnValueOnce(Promise.resolve([])) // list_clients
+    mockInvoke.mockReturnValueOnce(new Promise(() => {}))
 
     const onCancel = vi.fn()
     const user = userEvent.setup()
@@ -178,7 +174,8 @@ describe('createProject', () => {
   })
 
   it('displays error message on submit failure', async () => {
-    mockInvoke.mockRejectedValue(new Error('Database error'))
+    mockInvoke.mockReturnValueOnce(Promise.resolve([])) // list_clients
+    mockInvoke.mockRejectedValueOnce(new Error('Database error'))
 
     const user = userEvent.setup()
     render(<CreateProject />)
@@ -198,18 +195,9 @@ describe('createProject', () => {
   })
 
   it('clears error on new submit attempt', async () => {
+    mockInvoke.mockReturnValueOnce(Promise.resolve([])) // list_clients
     mockInvoke.mockRejectedValueOnce(new Error('First error'))
-    mockInvoke.mockResolvedValueOnce({
-      clientName: 'Test',
-      createdAt: '2025-11-20',
-      date: '2025-11-20',
-      folderPath: '/test/path',
-      id: '1',
-      name: 'Test',
-      shootType: '',
-      status: ProjectStatus.Editing,
-      updatedAt: '2025-11-20',
-    })
+    mockInvoke.mockResolvedValueOnce(mockProject)
 
     const user = userEvent.setup()
     render(<CreateProject />)
@@ -246,17 +234,5 @@ describe('createProject', () => {
 
     const optionalLabels = screen.getAllByText(/\(optional\)/)
     expect(optionalLabels.length).toBeGreaterThanOrEqual(2) // Shoot Type and Deadline
-  })
-
-  it('prevents form submission when required fields are empty', async () => {
-    const user = userEvent.setup()
-
-    render(<CreateProject />)
-
-    const submitButton = screen.getByText('Create Project')
-    await user.click(submitButton)
-
-    // HTML5 validation should prevent the invoke from being called
-    expect(invoke).not.toHaveBeenCalled()
   })
 })

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -39,20 +39,6 @@ export function Dashboard({ isActive, onProjectClick }: DashboardProps) {
     void loadData()
   }, [loadData])
 
-  // One-time migration: extract clients from existing projects
-  useEffect(() => {
-    const MIGRATION_KEY = 'clients_migrated_v1'
-    if (localStorage.getItem(MIGRATION_KEY)) return
-
-    invoke('migrate_clients_from_projects')
-      .then(() => {
-        localStorage.setItem(MIGRATION_KEY, '1')
-      })
-      .catch((err: unknown) => {
-        console.error('Client migration failed:', err)
-      })
-  }, [])
-
   function getStatusColor(status: string): string {
     switch (status) {
       case 'Importing': {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -39,6 +39,20 @@ export function Dashboard({ isActive, onProjectClick }: DashboardProps) {
     void loadData()
   }, [loadData])
 
+  // One-time migration: extract clients from existing projects
+  useEffect(() => {
+    const MIGRATION_KEY = 'clients_migrated_v1'
+    if (localStorage.getItem(MIGRATION_KEY)) return
+
+    invoke('migrate_clients_from_projects')
+      .then(() => {
+        localStorage.setItem(MIGRATION_KEY, '1')
+      })
+      .catch((err: unknown) => {
+        console.error('Client migration failed:', err)
+      })
+  }, [])
+
   function getStatusColor(status: string): string {
     switch (status) {
       case 'Importing': {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,6 +20,7 @@ interface LayoutProps {
   onNavigate: (view: string) => void
   importCount?: number
   projectsCount?: number
+  clientsCount?: number
 }
 
 export function Layout({
@@ -28,6 +29,7 @@ export function Layout({
   onNavigate,
   importCount,
   projectsCount,
+  clientsCount,
 }: LayoutProps) {
   return (
     <div className="app-container">
@@ -59,6 +61,13 @@ export function Layout({
               active={currentView === 'projects'}
               count={projectsCount}
               onClick={() => onNavigate('projects')}
+            />
+            <NavItem
+              icon="👥"
+              label="Clients"
+              active={currentView === 'clients'}
+              count={clientsCount}
+              onClick={() => onNavigate('clients')}
             />
           </NavSection>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,22 @@
 // Type definitions
 
+type ClientStatus = 'active' | 'archived'
+
+interface Client {
+  id: string
+  name: string
+  email?: string
+  phone?: string
+  notes?: string
+  status: ClientStatus
+  createdAt: string
+  updatedAt: string
+}
+
+interface ClientWithProjects extends Client {
+  projects: Project[]
+}
+
 interface SDCard {
   name: string
   path: string
@@ -21,6 +38,7 @@ interface Project {
   createdAt: string
   updatedAt: string
   deadline?: string
+  clientId?: string
 }
 
 enum ProjectStatus {
@@ -222,6 +240,9 @@ interface ProjectFile {
 }
 
 export type {
+  Client,
+  ClientStatus,
+  ClientWithProjects,
   SDCard,
   Project,
   ImportProgress,


### PR DESCRIPTION
## Motivation

Add client management to CreatorOps so photographers can associate shoots and deliveries with specific clients, enabling client-based filtering and delivery tracking.

## Implementation information

- Rust backend: `clients` SQLite table with CRUD commands (`create_client`, `list_clients`, `get_client`, `update_client`, `delete_client`)
- React frontend: `Clients` page with list view, create/edit modal, and delete confirmation
- Navigation wired into sidebar alongside existing Projects/Deliveries entries
- Follows existing patterns: `Result<T, String>` commands, `serde(rename_all = "camelCase")`, NotificationContext for errors, vanilla CSS with design tokens

Closes https://github.com/Automaat/creatorops/issues/14